### PR TITLE
WIP: Add logic and command to lint recording rules

### DIFF
--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -21,7 +21,7 @@ type RuleNamespace struct {
 }
 
 // LintPromQLExpressions runs the `expr` from a rule through the PromQL parser and
-// compares its output. if it differs from the parser, it uses the parser's instead.
+// compares its output. If it differs from the parser, it uses the parser's instead.
 func (r RuleNamespace) LintPromQLExpressions() (int, int, error) {
 	// `count` represents the number of rules we evalated.
 	// `mod` represents the number of rules linted.
@@ -49,6 +49,32 @@ func (r RuleNamespace) LintPromQLExpressions() (int, int, error) {
 	}
 
 	return count, mod, nil
+}
+
+// LintRecordingRules checks that recording rules have at least one colon in their name, this is based
+// on the recording rules best practices here: https://prometheus.io/docs/practices/rules/
+// Returns the number of rules that don't match the requirements, and error if that number is not 0.
+func (r RuleNamespace) LintRecordingRules() int {
+	var name string
+	var count int
+	for _, group := range r.Groups {
+		for _, rule := range group.Rules {
+			name = getRuleName(rule)
+			log.WithFields(log.Fields{"rule": name}).Debugf("linting recording rule name")
+			chunks := strings.Split(name, ":")
+			if len(chunks) < 3 {
+				count++
+				log.WithFields(log.Fields{
+					"rule":      getRuleName(rule),
+					"ruleGroup": group.Name,
+					"file":      r.Filepath,
+					"error":     "recording rule name does not match level:metric:operation format, must contain at least one colon",
+				}).Errorf("bad recording rule name")
+				// return fmt.Errorf("recording rule name %s does not match level:metric:operation format\n", name)
+			}
+		}
+	}
+	return count
 }
 
 // AggregateBy modifies the aggregation rules in groups to include a given Label.

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -63,6 +63,10 @@ func (r RuleNamespace) CheckRecordingRules(strict bool) int {
 	}
 	for _, group := range r.Groups {
 		for _, rule := range group.Rules {
+			// Assume if there is a rule.Record that this is a recording rule.
+			if rule.Record == "" {
+				continue
+			}
 			name = rule.Record
 			log.WithFields(log.Fields{"rule": name}).Debugf("linting recording rule name")
 			chunks := strings.Split(name, ":")

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -156,11 +156,12 @@ func TestLintPromQLExpressions(t *testing.T) {
 	}
 }
 
-func TestLintRecordingRules(t *testing.T) {
+func TestCheckRecordingRules(t *testing.T) {
 	tt := []struct {
 		name     string
 		ruleName string
 		count    int
+		strict   bool
 	}{
 		{
 			name:     "follows rule name conventions",
@@ -176,6 +177,12 @@ func TestLintRecordingRules(t *testing.T) {
 			name:     "almost follows rule name conventions",
 			ruleName: "level:metric_operation",
 			count:    1,
+			strict:   true,
+		},
+		{
+			name:     "almost follows rule name conventions",
+			ruleName: "level:metric_operation",
+			count:    0,
 		},
 		{
 			name:     "follows rule name conventions extra",
@@ -190,8 +197,8 @@ func TestLintRecordingRules(t *testing.T) {
 				{Record: tc.ruleName, Expr: "rate(some_metric_total)[5m]"},
 			}}}}
 
-			n := r.LintRecordingRules()
-			require.Equal(t, tc.count, n)
+			n := r.CheckRecordingRules(tc.strict)
+			require.Equal(t, tc.count, n, "failed rule: %s", tc.ruleName)
 		})
 	}
 }

--- a/pkg/rules/rules_test.go
+++ b/pkg/rules/rules_test.go
@@ -155,3 +155,43 @@ func TestLintPromQLExpressions(t *testing.T) {
 		})
 	}
 }
+
+func TestLintRecordingRules(t *testing.T) {
+	tt := []struct {
+		name     string
+		ruleName string
+		count    int
+	}{
+		{
+			name:     "follows rule name conventions",
+			ruleName: "level:metric:operation",
+			count:    0,
+		},
+		{
+			name:     "doesn't follow rule name conventions",
+			ruleName: "level_metric_operation",
+			count:    1,
+		},
+		{
+			name:     "almost follows rule name conventions",
+			ruleName: "level:metric_operation",
+			count:    1,
+		},
+		{
+			name:     "follows rule name conventions extra",
+			ruleName: "level:metric:something_else:operation",
+			count:    0,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			r := RuleNamespace{Groups: []rulefmt.RuleGroup{{Rules: []rulefmt.Rule{
+				{Record: tc.ruleName, Expr: "rate(some_metric_total)[5m]"},
+			}}}}
+
+			n := r.LintRecordingRules()
+			require.Equal(t, tc.count, n)
+		})
+	}
+}


### PR DESCRIPTION
Add logic and command to lint recording rules based on naming best practices. Best practices says the names should be `level:metric:operations`. We have some rules that are just `metric:operations`, which I think is reasonable. We might not always have an aggregation in a recording rule. But there are rules from the k8s-mixin that have no colon and are just a new `metric` name.

For now I've kept linting of the recording rules as a separate command, I'm not taking a stance on it needing to be that way but given that `lint` itself modifies the file it might be worth thinking about keeping this separate command that doesn't make any modifications. I've also added more details to the logging for this function than we have in the other linting function, if we want that there as well I can add it in this PR.

Signed-off-by: Callum Styan <callumstyan@gmail.com>