### PR TITLE
Update Docker builder image to Go 1.13

### DIFF
--- a/cmd/chunktool/Dockerfile
+++ b/cmd/chunktool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-stretch as build
+FROM golang:1.13.12-stretch as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir

--- a/cmd/cortextool/Dockerfile
+++ b/cmd/cortextool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-stretch as build
+FROM golang:1.13.12-stretch as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir

--- a/cmd/logtool/Dockerfile
+++ b/cmd/logtool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-stretch as build
+FROM golang:1.13.12-stretch as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir


### PR DESCRIPTION
With #47 we seem to have updated our `go.mod` to Go 1.13. Our docker
Image builders were trying to use Go 1.12 to build and kept failing due to
a dependency problem. It appears `go.mod`'s are incompatible across 1.12
and 1.13.

I have already drafted the release and there's no point in building the binaries again given that this only affects docker image building.