### PR TITLE
rules get: properly print without color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased / master
 
+* [BUGFIX] When using `--disable-color` for `rules get`, it now actually prints rules instead of the bytes of the underlying string
+
 ## v0.2.2 / 2020-06-09
 
 * [BUGFIX] Remove usage of alternate PromQL parser in `rules prepare lint`.

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -101,7 +101,7 @@ func (p *Printer) PrintRuleGroup(rule rulefmt.RuleGroup) error {
 		return quick.Highlight(os.Stdout, string(encodedRule), "yaml", "terminal", "swapoff")
 	}
 
-	fmt.Println(encodedRule)
+	fmt.Println(string(encodedRule))
 
 	return nil
 }


### PR DESCRIPTION
Previously printed a byte slice, now prints a string