### PR TITLE
Add alerts command to compare alerts

### DIFF
--- a/cmd/cortextool/main.go
+++ b/cmd/cortextool/main.go
@@ -27,4 +27,17 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	pushGateway.Stop()
+	// cli.GetAlertmanagerURL()
+
+	// amcli := cli.NewAlertmanagerClient(&url.URL{
+	// 	Host: "localhost:8080",
+	// 	Path: "alertmanager",
+	// })
+
+	// groups, _ := amcli.Alertgroup.GetAlertGroups(nil)
+	// for _, group := range groups.Payload {
+	// 	if len(group.Alerts)%2 != 0 && !strings.Contains(group.Labels["cluster"], "agent") {
+	// 		fmt.Printf("%+v, %+v\n", group.Labels["alertname"], group.Labels)
+	// 	}
+	// }
 }

--- a/cmd/cortextool/main.go
+++ b/cmd/cortextool/main.go
@@ -27,17 +27,4 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	pushGateway.Stop()
-	// cli.GetAlertmanagerURL()
-
-	// amcli := cli.NewAlertmanagerClient(&url.URL{
-	// 	Host: "localhost:8080",
-	// 	Path: "alertmanager",
-	// })
-
-	// groups, _ := amcli.Alertgroup.GetAlertGroups(nil)
-	// for _, group := range groups.Payload {
-	// 	if len(group.Alerts)%2 != 0 && !strings.Contains(group.Labels["cluster"], "agent") {
-	// 		fmt.Printf("%+v, %+v\n", group.Labels["alertname"], group.Labels)
-	// 	}
-	// }
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -49,6 +51,20 @@ func New(cfg Config) (*CortexClient, error) {
 		endpoint: endpoint,
 		client:   http.Client{},
 	}, nil
+}
+
+// Query executes a PromQL query against the Cortex cluster.
+func (r *CortexClient) Query(ctx context.Context, query string) (*http.Response, error) {
+
+	query = fmt.Sprintf("query=%s&time=%d", query, time.Now().Unix())
+	escapedQuery := url.PathEscape(query)
+
+	res, err := r.doRequest("/api/prom/api/v1/query?"+escapedQuery, "GET", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
 func (r *CortexClient) doRequest(path, method string, payload []byte) (*http.Response, error) {

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -6,18 +6,10 @@ import (
 	"fmt"
 	"strings"
 
-	// "fmt"
 	"io/ioutil"
 	"net/url"
 
-	// "strings"
-	// "time"
-
 	"github.com/pkg/errors"
-
-	// amClient "github.com/prometheus/alertmanager/api/v2/client"
-
-	// amCli "github.com/prometheus/alertmanager/cli"
 
 	"github.com/prometheus/alertmanager/config"
 
@@ -132,7 +124,7 @@ func (a *AlertCommand) Register(app *kingpin.Application) {
 	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
 	alertCmd.Flag("key", "Api key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&a.ClientConfig.Key)
 
-	verifyAlertsCmd := alertCmd.Command("verify", "Verifies alerts in an alertmanager cluster are deduplicated; useful for verifying correct configuration when transfering from Prometheus to Cortex alert evaluation.").Action(a.verifyConfig)
+	verifyAlertsCmd := alertCmd.Command("verify", "Verifies alerts in an alertmanager cluster are deduplicated; useful for verifying correct configuration when transferring from Prometheus to Cortex alert evaluation.").Action(a.verifyConfig)
 	verifyAlertsCmd.Flag("ignore-alerts", "A comma separated list of Alert names to ignore in deduplication checks.").StringVar(&a.IgnoreString)
 	verifyAlertsCmd.Flag("source-label", "Label to look for when deciding if two alerts are duplicates of eachother from separate sources.").Default("ruler").StringVar(&a.SourceLabel)
 	verifyAlertsCmd.Flag("grace-period", "Grace period, don't consider alert groups with the incorrect amount of alert replicas erroneous unless the alerts have existed for more than this amount of time, in minutes.").Default("5").IntVar(&a.GracePeriod)
@@ -182,17 +174,17 @@ func (a *AlertCommand) verifyConfig(k *kingpin.ParseContext) error {
 		a.GracePeriod,
 		a.SourceLabel)
 	res, err := a.cli.Query(context.Background(), fmt.Sprintf("%s or %s", lhs, rhs))
-	defer res.Body.Close()
 
 	if err != nil {
 		return err
 	}
 
 	body, err := ioutil.ReadAll(res.Body)
-
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
+
 	var data queryResult
 	err = json.Unmarshal(body, &data)
 	if err != nil {

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -193,7 +193,10 @@ func (a *AlertCommand) verifyConfig(k *kingpin.ParseContext) error {
 
 	for _, m := range data.Data.Result {
 		if _, ok := a.IgnoreAlerts[m.Metric["alertname"]]; !ok {
-			log.Infof("bad alert: %s, %+v", m.Metric["alertname"], m.Metric)
+			log.WithFields(log.Fields{
+				"alertname": m.Metric["alertname"],
+				"state":     m.Metric,
+			}).Infof("bad alert")
 		}
 	}
 

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -199,6 +199,6 @@ func (a *AlertCommand) verifyConfig(k *kingpin.ParseContext) error {
 			}).Infof("bad alert")
 		}
 	}
-
+	log.WithFields(log.Fields{"count": len(data.Data.Result)}).Infof("found mismatching alerts")
 	return nil
 }

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -2,10 +2,25 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	// "fmt"
 	"io/ioutil"
+	"net/url"
+
+	// "strings"
+	// "time"
 
 	"github.com/pkg/errors"
+
+	// amClient "github.com/prometheus/alertmanager/api/v2/client"
+
+	// amCli "github.com/prometheus/alertmanager/cli"
+
 	"github.com/prometheus/alertmanager/config"
+
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
@@ -13,9 +28,10 @@ import (
 	"github.com/grafana/cortex-tools/pkg/printer"
 )
 
-// AlertCommand configures and executes rule related cortex api operations
-type AlertCommand struct {
+// AlertmanagerCommand configures and executes rule related cortex api operations
+type AlertmanagerCommand struct {
 	ClientConfig           client.Config
+	AlertmanagerURL        url.URL
 	AlertmanagerConfigFile string
 	TemplateFiles          []string
 	DisableColor           bool
@@ -23,8 +39,20 @@ type AlertCommand struct {
 	cli *client.CortexClient
 }
 
+// AlertCommand configures and executes rule related PromQL queries for alerts comparison.
+type AlertCommand struct {
+	CortexURL    string
+	IgnoreString string
+	IgnoreAlerts map[string]interface{}
+	SourceLabel  string
+	NumSources   int
+	GracePeriod  int
+	ClientConfig client.Config
+	cli          *client.CortexClient
+}
+
 // Register rule related commands and flags with the kingpin application
-func (a *AlertCommand) Register(app *kingpin.Application) {
+func (a *AlertmanagerCommand) Register(app *kingpin.Application) {
 	alertCmd := app.Command("alertmanager", "View & edit alertmanager configs stored in cortex.").PreAction(a.setup)
 	alertCmd.Flag("address", "Address of the cortex cluster, alternatively set CORTEX_ADDRESS.").Envar("CORTEX_ADDRESS").Required().StringVar(&a.ClientConfig.Address)
 	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
@@ -41,7 +69,7 @@ func (a *AlertCommand) Register(app *kingpin.Application) {
 	loadalertCmd.Arg("template-files", "The template files to load").ExistingFilesVar(&a.TemplateFiles)
 }
 
-func (a *AlertCommand) setup(k *kingpin.ParseContext) error {
+func (a *AlertmanagerCommand) setup(k *kingpin.ParseContext) error {
 	cli, err := client.New(a.ClientConfig)
 	if err != nil {
 		return err
@@ -51,7 +79,7 @@ func (a *AlertCommand) setup(k *kingpin.ParseContext) error {
 	return nil
 }
 
-func (a *AlertCommand) getConfig(k *kingpin.ParseContext) error {
+func (a *AlertmanagerCommand) getConfig(k *kingpin.ParseContext) error {
 	cfg, templates, err := a.cli.GetAlertmanagerConfig(context.Background())
 	if err != nil {
 		if err == client.ErrResourceNotFound {
@@ -66,7 +94,7 @@ func (a *AlertCommand) getConfig(k *kingpin.ParseContext) error {
 	return p.PrintAlertmanagerConfig(cfg, templates)
 }
 
-func (a *AlertCommand) loadConfig(k *kingpin.ParseContext) error {
+func (a *AlertmanagerCommand) loadConfig(k *kingpin.ParseContext) error {
 	content, err := ioutil.ReadFile(a.AlertmanagerConfigFile)
 	if err != nil {
 		return errors.Wrap(err, "unable to load config file: "+a.AlertmanagerConfigFile)
@@ -90,10 +118,92 @@ func (a *AlertCommand) loadConfig(k *kingpin.ParseContext) error {
 	return a.cli.CreateAlertmanagerConfig(context.Background(), cfg, templates)
 }
 
-func (a *AlertCommand) deleteConfig(k *kingpin.ParseContext) error {
+func (a *AlertmanagerCommand) deleteConfig(k *kingpin.ParseContext) error {
 	err := a.cli.DeleteAlermanagerConfig(context.Background())
 	if err != nil && err != client.ErrResourceNotFound {
 		return err
 	}
+	return nil
+}
+
+func (a *AlertCommand) Register(app *kingpin.Application) {
+	alertCmd := app.Command("alerts", "View active alerts in alertmanager.").PreAction(a.setup)
+	alertCmd.Flag("address", "Address of the cortex cluster, alternatively set CORTEX_ADDRESS.").Envar("CORTEX_ADDRESS").Required().StringVar(&a.ClientConfig.Address)
+	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
+	alertCmd.Flag("key", "Api key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&a.ClientConfig.Key)
+
+	verifyAlertsCmd := alertCmd.Command("verify", "Verifies alerts in an alertmanager cluster are deduplicated; useful for verifying correct configuration when transfering from Prometheus to Cortex alert evaluation.").Action(a.verifyConfig)
+	verifyAlertsCmd.Flag("ignore-alerts", "A comma separated list of Alert names to ignore in deduplication checks.").StringVar(&a.IgnoreString)
+	verifyAlertsCmd.Flag("source-label", "Label to look for when deciding if two alerts are duplicates of eachother from separate sources.").Default("ruler").StringVar(&a.SourceLabel)
+	verifyAlertsCmd.Flag("grace-period", "Grace period, don't consider alert groups with the incorrect amount of alert replicas erroneous unless the alerts have existed for more than this amount of time, in minutes.").Default("5").IntVar(&a.GracePeriod)
+}
+
+func (a *AlertCommand) setup(k *kingpin.ParseContext) error {
+	cli, err := client.New(a.ClientConfig)
+	if err != nil {
+		return err
+	}
+	a.cli = cli
+
+	return nil
+}
+
+type queryResult struct {
+	Status string    `json:"status"`
+	Data   queryData `json:"data"`
+}
+
+type queryData struct {
+	ResultType string   `json:"resultType"`
+	Result     []metric `json:"result"`
+}
+
+type metric struct {
+	Metric map[string]string `json:"metric"`
+}
+
+func (a *AlertCommand) verifyConfig(k *kingpin.ParseContext) error {
+	var empty interface{}
+	if a.IgnoreString != "" {
+		a.IgnoreAlerts = make(map[string]interface{})
+		chunks := strings.Split(a.IgnoreString, ",")
+
+		for _, name := range chunks {
+			a.IgnoreAlerts[name] = empty
+			log.Info("Ignoring alerts with name: ", name)
+		}
+	}
+	lhs := fmt.Sprintf("ALERTS{source!=\"%s\", alertstate=\"firing\"} offset %dm unless ignoring(source) ALERTS{source=\"%s\", alertstate=\"firing\"}",
+		a.SourceLabel,
+		a.GracePeriod,
+		a.SourceLabel)
+	rhs := fmt.Sprintf("ALERTS{source=\"%s\", alertstate=\"firing\"} offset %dm unless ignoring(source) ALERTS{source!=\"%s\", alertstate=\"firing\"}",
+		a.SourceLabel,
+		a.GracePeriod,
+		a.SourceLabel)
+	res, err := a.cli.Query(context.Background(), fmt.Sprintf("%s or %s", lhs, rhs))
+	defer res.Body.Close()
+
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return err
+	}
+	var data queryResult
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range data.Data.Result {
+		if _, ok := a.IgnoreAlerts[m.Metric["alertname"]]; !ok {
+			log.Infof("bad alert: %s, %+v", m.Metric["alertname"], m.Metric)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
Relatively simple. The query basically looks for alerts that are generated by Prometheus but not the ruler, or the opposite. 

More or less done but could do with some clean up and I haven't included the vendor changes since I vendored a lot of alertmanager stuff when I was still going down that route so I need to fix that first.

Signed-off-by: Callum Styan <callumstyan@gmail.com>