### PR TITLE
Allow mutualTLS for Cortex API client for rules and alertmanager cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## unreleased / master
 
 * [BUGFIX] When using `--disable-color` for `rules get`, it now actually prints rules instead of the bytes of the underlying string
+* [ENHANCEMENT] Allow mutualTLS for Cortex API client for `rules` and `alertmanager` cmds with:
+  - `--tls-ca-path` or `CORTEX_TLS_CA_PATH`
+  - `--tls-cert-path` or `CORTEX_TLS_CERT_PATH`
+  - `--tls-key-path` or `CORTEX_TLS_KEY_PATH`
 
 ## v0.2.2 / 2020-06-09
 

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -29,6 +29,9 @@ func (a *AlertCommand) Register(app *kingpin.Application) {
 	alertCmd.Flag("address", "Address of the cortex cluster, alternatively set CORTEX_ADDRESS.").Envar("CORTEX_ADDRESS").Required().StringVar(&a.ClientConfig.Address)
 	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
 	alertCmd.Flag("key", "Api key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&a.ClientConfig.Key)
+	alertCmd.Flag("tls-ca-cert", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_CERT.").Default("").Envar("CORTEX_TLS_CA_CERT").StringVar(&a.ClientConfig.TLScaFile)
+	alertCmd.Flag("tls-cert", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_CERT.").Default("").Envar("CORTEX_TLS_CLIENT_CERT").StringVar(&a.ClientConfig.TLScertFile)
+	alertCmd.Flag("tls-key", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_KEY.").Default("").Envar("CORTEX_TLS_CLIENT_KEY").StringVar(&a.ClientConfig.TLSkeyFile)
 
 	// Get Alertmanager Configs Command
 	getAlertsCmd := alertCmd.Command("get", "Get the alertmanager config currently in the cortex alertmanager.").Action(a.getConfig)

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -29,9 +29,9 @@ func (a *AlertCommand) Register(app *kingpin.Application) {
 	alertCmd.Flag("address", "Address of the cortex cluster, alternatively set CORTEX_ADDRESS.").Envar("CORTEX_ADDRESS").Required().StringVar(&a.ClientConfig.Address)
 	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
 	alertCmd.Flag("key", "Api key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&a.ClientConfig.Key)
-	alertCmd.Flag("tls-ca-cert", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_CERT.").Default("").Envar("CORTEX_TLS_CA_CERT").StringVar(&a.ClientConfig.TLS.CAPath)
-	alertCmd.Flag("tls-cert", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_CERT.").Default("").Envar("CORTEX_TLS_CLIENT_CERT").StringVar(&a.ClientConfig.TLS.CertPath)
-	alertCmd.Flag("tls-key", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_KEY.").Default("").Envar("CORTEX_TLS_CLIENT_KEY").StringVar(&a.ClientConfig.TLS.KeyPath)
+	alertCmd.Flag("tls-ca-path", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_PATH.").Default("").Envar("CORTEX_TLS_CA_PATH").StringVar(&a.ClientConfig.TLS.CAPath)
+	alertCmd.Flag("tls-cert-path", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CERT_PATH.").Default("").Envar("CORTEX_TLS_CERT_PATH").StringVar(&a.ClientConfig.TLS.CertPath)
+	alertCmd.Flag("tls-key-path", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_KEY_PATH.").Default("").Envar("CORTEX_TLS_KEY_PATH").StringVar(&a.ClientConfig.TLS.KeyPath)
 
 	// Get Alertmanager Configs Command
 	getAlertsCmd := alertCmd.Command("get", "Get the alertmanager config currently in the cortex alertmanager.").Action(a.getConfig)

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -29,9 +29,9 @@ func (a *AlertCommand) Register(app *kingpin.Application) {
 	alertCmd.Flag("address", "Address of the cortex cluster, alternatively set CORTEX_ADDRESS.").Envar("CORTEX_ADDRESS").Required().StringVar(&a.ClientConfig.Address)
 	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
 	alertCmd.Flag("key", "Api key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&a.ClientConfig.Key)
-	alertCmd.Flag("tls-ca-cert", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_CERT.").Default("").Envar("CORTEX_TLS_CA_CERT").StringVar(&a.ClientConfig.TLScaFile)
-	alertCmd.Flag("tls-cert", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_CERT.").Default("").Envar("CORTEX_TLS_CLIENT_CERT").StringVar(&a.ClientConfig.TLScertFile)
-	alertCmd.Flag("tls-key", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_KEY.").Default("").Envar("CORTEX_TLS_CLIENT_KEY").StringVar(&a.ClientConfig.TLSkeyFile)
+	alertCmd.Flag("tls-ca-cert", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_CERT.").Default("").Envar("CORTEX_TLS_CA_CERT").StringVar(&a.ClientConfig.TLS.CAPath)
+	alertCmd.Flag("tls-cert", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_CERT.").Default("").Envar("CORTEX_TLS_CLIENT_CERT").StringVar(&a.ClientConfig.TLS.CertPath)
+	alertCmd.Flag("tls-key", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_KEY.").Default("").Envar("CORTEX_TLS_CLIENT_KEY").StringVar(&a.ClientConfig.TLS.KeyPath)
 
 	// Get Alertmanager Configs Command
 	getAlertsCmd := alertCmd.Command("get", "Get the alertmanager config currently in the cortex alertmanager.").Action(a.getConfig)

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -117,6 +117,22 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 			Envar("CORTEX_TENANT_ID").
 			Required().
 			StringVar(&r.ClientConfig.ID)
+
+		c.Flag("tls-ca-cert", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_CERT.").
+			Default("").
+			Envar("CORTEX_TLS_CA_CERT").
+			StringVar(&r.ClientConfig.TLScaFile)
+
+		c.Flag("tls-cert", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_CERT.").
+			Default("").
+			Envar("CORTEX_TLS_CLIENT_CERT").
+			StringVar(&r.ClientConfig.TLScertFile)
+
+		c.Flag("tls-key", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_KEY.").
+			Default("").
+			Envar("CORTEX_TLS_CLIENT_KEY").
+			StringVar(&r.ClientConfig.TLSkeyFile)
+
 	}
 
 	// Print Rules Command

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -121,17 +121,17 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 		c.Flag("tls-ca-cert", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_CERT.").
 			Default("").
 			Envar("CORTEX_TLS_CA_CERT").
-			StringVar(&r.ClientConfig.TLScaFile)
+			StringVar(&r.ClientConfig.TLS.CAPath)
 
 		c.Flag("tls-cert", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_CERT.").
 			Default("").
 			Envar("CORTEX_TLS_CLIENT_CERT").
-			StringVar(&r.ClientConfig.TLScertFile)
+			StringVar(&r.ClientConfig.TLS.CertPath)
 
 		c.Flag("tls-key", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_KEY.").
 			Default("").
 			Envar("CORTEX_TLS_CLIENT_KEY").
-			StringVar(&r.ClientConfig.TLSkeyFile)
+			StringVar(&r.ClientConfig.TLS.KeyPath)
 
 	}
 

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -118,17 +118,17 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 			Required().
 			StringVar(&r.ClientConfig.ID)
 
-		c.Flag("tls-ca-cert", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_CERT.").
+		c.Flag("tls-ca-path", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_PATH.").
 			Default("").
 			Envar("CORTEX_TLS_CA_CERT").
 			StringVar(&r.ClientConfig.TLS.CAPath)
 
-		c.Flag("tls-cert", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_CERT.").
+		c.Flag("tls-cert-path", "TLS client certificate to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CERT_PATH.").
 			Default("").
 			Envar("CORTEX_TLS_CLIENT_CERT").
 			StringVar(&r.ClientConfig.TLS.CertPath)
 
-		c.Flag("tls-key", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_CLIENT_KEY.").
+		c.Flag("tls-key-path", "TLS client certificate private key to authenticate with cortex API as part of mTLS, alternatively set CORTEX_TLS_KEY_PATH.").
 			Default("").
 			Envar("CORTEX_TLS_CLIENT_KEY").
 			StringVar(&r.ClientConfig.TLS.KeyPath)


### PR DESCRIPTION
https://github.com/grafana/cortex-tools/issues/63

Allow rules and alertmanager commands to authenticate with Cortex API using mutual TLS (aka TLS client verification).

http client transport is set with tlsConfig when CA cert, client cert and client key are given as cli parameters.

Let me know if you find more cmds that would need mTLS



