### PR TITLE
Match application naming to the GitHub naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased / master
 
+* [BUGFIX] Renamed module from cortextool to cortex-tools to ensure `go get` works properly.
 * [BUGFIX] When using `--disable-color` for `rules get`, it now actually prints rules instead of the bytes of the underlying string
 
 ## v0.2.2 / 2020-06-09

--- a/cmd/chunktool/main.go
+++ b/cmd/chunktool/main.go
@@ -5,7 +5,7 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/grafana/cortextool/pkg/commands"
+	"github.com/grafana/cortex-tools/pkg/commands"
 )
 
 var (

--- a/cmd/cortextool/main.go
+++ b/cmd/cortextool/main.go
@@ -5,7 +5,7 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/grafana/cortextool/pkg/commands"
+	"github.com/grafana/cortex-tools/pkg/commands"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafana/cortextool
+module github.com/grafana/cortex-tools
 
 go 1.13
 

--- a/pkg/chunk/gcp/bigtable_delete.go
+++ b/pkg/chunk/gcp/bigtable_delete.go
@@ -11,7 +11,7 @@ import (
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 
-	chunkTool "github.com/grafana/cortextool/pkg/chunk"
+	chunkTool "github.com/grafana/cortex-tools/pkg/chunk"
 )
 
 const (

--- a/pkg/chunk/gcp/bigtable_scanner.go
+++ b/pkg/chunk/gcp/bigtable_scanner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/chunk"
 	"github.com/sirupsen/logrus"
 
-	chunkTool "github.com/grafana/cortextool/pkg/chunk"
+	chunkTool "github.com/grafana/cortex-tools/pkg/chunk"
 )
 
 type bigtableScanner struct {

--- a/pkg/chunk/gcp/gcs_scanner.go
+++ b/pkg/chunk/gcp/gcs_scanner.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
-	chunkTool "github.com/grafana/cortextool/pkg/chunk"
+	chunkTool "github.com/grafana/cortex-tools/pkg/chunk"
 )
 
 type gcsScanner struct {

--- a/pkg/chunk/migrate/migrator.go
+++ b/pkg/chunk/migrate/migrator.go
@@ -7,8 +7,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"github.com/grafana/cortextool/pkg/chunk/migrate/reader"
-	"github.com/grafana/cortextool/pkg/chunk/migrate/writer"
+	"github.com/grafana/cortex-tools/pkg/chunk/migrate/reader"
+	"github.com/grafana/cortex-tools/pkg/chunk/migrate/writer"
 )
 
 const chunkBufferSize = 1000

--- a/pkg/chunk/migrate/reader/planner.go
+++ b/pkg/chunk/migrate/reader/planner.go
@@ -6,7 +6,7 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/grafana/cortextool/pkg/chunk"
+	"github.com/grafana/cortex-tools/pkg/chunk"
 )
 
 // PlannerConfig is used to configure the Planner

--- a/pkg/chunk/migrate/reader/reader.go
+++ b/pkg/chunk/migrate/reader/reader.go
@@ -10,8 +10,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
-	"github.com/grafana/cortextool/pkg/chunk"
-	"github.com/grafana/cortextool/pkg/chunk/storage"
+	"github.com/grafana/cortex-tools/pkg/chunk"
+	"github.com/grafana/cortex-tools/pkg/chunk/storage"
 )
 
 var (

--- a/pkg/chunk/storage/factory.go
+++ b/pkg/chunk/storage/factory.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk/storage"
 
-	"github.com/grafana/cortextool/pkg/chunk"
-	"github.com/grafana/cortextool/pkg/chunk/gcp"
+	"github.com/grafana/cortex-tools/pkg/chunk"
+	"github.com/grafana/cortex-tools/pkg/chunk/gcp"
 )
 
 // NewChunkScanner makes a new table client based on the configuration.

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -9,8 +9,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/grafana/cortextool/pkg/client"
-	"github.com/grafana/cortextool/pkg/printer"
+	"github.com/grafana/cortex-tools/pkg/client"
+	"github.com/grafana/cortex-tools/pkg/printer"
 )
 
 // AlertCommand configures and executes rule related cortex api operations

--- a/pkg/commands/chunks.go
+++ b/pkg/commands/chunks.go
@@ -18,10 +18,10 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
 
-	chunkTool "github.com/grafana/cortextool/pkg/chunk"
-	"github.com/grafana/cortextool/pkg/chunk/filter"
-	toolGCP "github.com/grafana/cortextool/pkg/chunk/gcp"
-	"github.com/grafana/cortextool/pkg/chunk/migrate"
+	chunkTool "github.com/grafana/cortex-tools/pkg/chunk"
+	"github.com/grafana/cortex-tools/pkg/chunk/filter"
+	toolGCP "github.com/grafana/cortex-tools/pkg/chunk/gcp"
+	"github.com/grafana/cortex-tools/pkg/chunk/migrate"
 )
 
 var (

--- a/pkg/commands/migrate.go
+++ b/pkg/commands/migrate.go
@@ -6,8 +6,8 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
 
-	"github.com/grafana/cortextool/pkg/chunk/migrate"
-	"github.com/grafana/cortextool/pkg/chunk/migrate/reader"
+	"github.com/grafana/cortex-tools/pkg/chunk/migrate"
+	"github.com/grafana/cortex-tools/pkg/chunk/migrate/reader"
 )
 
 type migrateChunksCommandOptions struct {

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -15,9 +15,9 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	yamlv3 "gopkg.in/yaml.v3"
 
-	"github.com/grafana/cortextool/pkg/client"
-	"github.com/grafana/cortextool/pkg/printer"
-	"github.com/grafana/cortextool/pkg/rules"
+	"github.com/grafana/cortex-tools/pkg/client"
+	"github.com/grafana/cortex-tools/pkg/printer"
+	"github.com/grafana/cortex-tools/pkg/rules"
 )
 
 const (

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mitchellh/colorstring"
 	"gopkg.in/yaml.v2"
 
-	"github.com/grafana/cortextool/pkg/rules"
+	"github.com/grafana/cortex-tools/pkg/rules"
 )
 
 // Printer is  used for printing formatted output from the cortextool


### PR DESCRIPTION
At some point, the repository was renamed from cortextool to
cortex-tools. Let's make sure we reflect that in the commands to ensure
`go get` works as expected.

fixes #59 