### PR TITLE
Fix alertmanager subcommand and path for the configuration API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased / master
 
+* [BUGFIX] Fix alertmanager registration subcommand and path for the configuration API #72
+
 ## v0.2.3
 
 * [FEATURE] Added `alerts verify` command, which can be used to compare `ALERTS` series in Cortex to verify if Prometheus and Cortex Ruler are firing the same alerts

--- a/cmd/cortextool/main.go
+++ b/cmd/cortextool/main.go
@@ -9,11 +9,12 @@ import (
 )
 
 var (
-	ruleCommand    commands.RuleCommand
-	alertCommand   commands.AlertCommand
-	logConfig      commands.LoggerConfig
-	pushGateway    commands.PushGatewayConfig
-	loadgenCommand commands.LoadgenCommand
+	ruleCommand         commands.RuleCommand
+	alertCommand        commands.AlertCommand
+	alertmanagerCommand commands.AlertmanagerCommand
+	logConfig           commands.LoggerConfig
+	pushGateway         commands.PushGatewayConfig
+	loadgenCommand      commands.LoadgenCommand
 )
 
 func main() {
@@ -21,6 +22,7 @@ func main() {
 	app := kingpin.New("cortextool", "A command-line tool to manage cortex.")
 	logConfig.Register(app)
 	alertCommand.Register(app)
+	alertmanagerCommand.Register(app)
 	ruleCommand.Register(app)
 	pushGateway.Register(app)
 	loadgenCommand.Register(app)

--- a/pkg/client/alerts.go
+++ b/pkg/client/alerts.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const alertmanagerAPIPath = "/api/v1/alerts"
+
 type configCompat struct {
 	TemplateFiles      map[string]string `yaml:"template_files"`
 	AlertmanagerConfig string            `yaml:"alertmanager_config"`
@@ -24,19 +26,19 @@ func (r *CortexClient) CreateAlertmanagerConfig(ctx context.Context, cfg string,
 		return err
 	}
 
-	_, err = r.doRequest("/alertmanager/alerts", "POST", payload)
+	_, err = r.doRequest(alertmanagerAPIPath, "POST", payload)
 	return err
 }
 
 // DeleteAlermanagerConfig deletes the users alertmanagerconfig
 func (r *CortexClient) DeleteAlermanagerConfig(ctx context.Context) error {
-	_, err := r.doRequest("/alertmanager/alerts", "DELETE", nil)
+	_, err := r.doRequest(alertmanagerAPIPath, "DELETE", nil)
 	return err
 }
 
 // GetAlertmanagerConfig retrieves a rule group
 func (r *CortexClient) GetAlertmanagerConfig(ctx context.Context) (string, map[string]string, error) {
-	res, err := r.doRequest("/alertmanager/alerts", "GET", nil)
+	res, err := r.doRequest(alertmanagerAPIPath, "GET", nil)
 	if err != nil {
 		log.Debugln("no alert config present in response")
 		return "", nil, err


### PR DESCRIPTION
This PR fixes two things:

- Seems like the Alertmanager subcommand got unregistered as we renamed it.
- Uses the new Alertmanager path for the configuration API in accordance with what's in Cortex upstream. 