### PR TITLE
Custom rulefmt package with remote-write configs

### DIFF
--- a/pkg/client/rules.go
+++ b/pkg/client/rules.go
@@ -6,13 +6,14 @@ import (
 	"net/url"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/prometheus/pkg/rulefmt"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 )
 
 // CreateRuleGroup creates a new rule group
-func (r *CortexClient) CreateRuleGroup(ctx context.Context, namespace string, rg rulefmt.RuleGroup) error {
+func (r *CortexClient) CreateRuleGroup(ctx context.Context, namespace string, rg rwrulefmt.RuleGroup) error {
 	payload, err := yaml.Marshal(&rg)
 	if err != nil {
 		return err
@@ -39,7 +40,7 @@ func (r *CortexClient) DeleteRuleGroup(ctx context.Context, namespace, groupName
 }
 
 // GetRuleGroup retrieves a rule group
-func (r *CortexClient) GetRuleGroup(ctx context.Context, namespace, groupName string) (*rulefmt.RuleGroup, error) {
+func (r *CortexClient) GetRuleGroup(ctx context.Context, namespace, groupName string) (*rwrulefmt.RuleGroup, error) {
 	escapedNamespace := url.PathEscape(namespace)
 	escapedGroupName := url.PathEscape(groupName)
 	path := "/api/prom/rules/" + escapedNamespace + "/" + escapedGroupName
@@ -60,7 +61,7 @@ func (r *CortexClient) GetRuleGroup(ctx context.Context, namespace, groupName st
 		return nil, err
 	}
 
-	rg := rulefmt.RuleGroup{}
+	rg := rwrulefmt.RuleGroup{}
 	err = yaml.Unmarshal(body, &rg)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -74,7 +75,7 @@ func (r *CortexClient) GetRuleGroup(ctx context.Context, namespace, groupName st
 }
 
 // ListRules retrieves a rule group
-func (r *CortexClient) ListRules(ctx context.Context, namespace string) (map[string][]rulefmt.RuleGroup, error) {
+func (r *CortexClient) ListRules(ctx context.Context, namespace string) (map[string][]rwrulefmt.RuleGroup, error) {
 	path := "/api/prom/rules"
 	if namespace != "" {
 		path = path + "/" + namespace
@@ -92,7 +93,7 @@ func (r *CortexClient) ListRules(ctx context.Context, namespace string) (map[str
 		return nil, err
 	}
 
-	ruleSet := map[string][]rulefmt.RuleGroup{}
+	ruleSet := map[string][]rwrulefmt.RuleGroup{}
 	err = yaml.Unmarshal(body, &ruleSet)
 	if err != nil {
 		return nil, err

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/alecthomas/chroma/quick"
 	"github.com/mitchellh/colorstring"
-	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/cortex-tools/pkg/rules"
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 )
 
 // Printer is  used for printing formatted output from the cortextool
@@ -73,7 +73,7 @@ func (p *Printer) PrintAlertmanagerConfig(config string, templates map[string]st
 }
 
 // PrintRuleGroups prints the current alertmanager config
-func (p *Printer) PrintRuleGroups(rules map[string][]rulefmt.RuleGroup) error {
+func (p *Printer) PrintRuleGroups(rules map[string][]rwrulefmt.RuleGroup) error {
 	encodedRules, err := yaml.Marshal(&rules)
 	if err != nil {
 		return err
@@ -90,7 +90,7 @@ func (p *Printer) PrintRuleGroups(rules map[string][]rulefmt.RuleGroup) error {
 }
 
 // PrintRuleGroup prints the current alertmanager config
-func (p *Printer) PrintRuleGroup(rule rulefmt.RuleGroup) error {
+func (p *Printer) PrintRuleGroup(rule rwrulefmt.RuleGroup) error {
 	encodedRule, err := yaml.Marshal(&rule)
 	if err != nil {
 		return err

--- a/pkg/rules/compare.go
+++ b/pkg/rules/compare.go
@@ -9,6 +9,8 @@ import (
 	"github.com/mitchellh/colorstring"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 )
 
 var (
@@ -38,8 +40,8 @@ type NamespaceChange struct {
 	Namespace     string
 	State         NamespaceState
 	GroupsUpdated []UpdatedRuleGroup
-	GroupsCreated []rulefmt.RuleGroup
-	GroupsDeleted []rulefmt.RuleGroup
+	GroupsCreated []rwrulefmt.RuleGroup
+	GroupsDeleted []rwrulefmt.RuleGroup
 }
 
 // SummarizeChanges returns the number of each type of change in a set of changes
@@ -61,12 +63,12 @@ func SummarizeChanges(changes []NamespaceChange) (created, updated, deleted int)
 
 // UpdatedRuleGroup is used to store an change between a rule group
 type UpdatedRuleGroup struct {
-	New      rulefmt.RuleGroup
-	Original rulefmt.RuleGroup
+	New      rwrulefmt.RuleGroup
+	Original rwrulefmt.RuleGroup
 }
 
 // CompareGroups differentiates between two rule groups
-func CompareGroups(groupOne, groupTwo rulefmt.RuleGroup) error {
+func CompareGroups(groupOne, groupTwo rwrulefmt.RuleGroup) error {
 	if groupOne.Name != groupTwo.Name {
 		return errNameDiff
 	}
@@ -123,11 +125,11 @@ func CompareNamespaces(original, new RuleNamespace) NamespaceChange {
 		Namespace:     new.Namespace,
 		State:         Unchanged,
 		GroupsUpdated: []UpdatedRuleGroup{},
-		GroupsCreated: []rulefmt.RuleGroup{},
-		GroupsDeleted: []rulefmt.RuleGroup{},
+		GroupsCreated: []rwrulefmt.RuleGroup{},
+		GroupsDeleted: []rwrulefmt.RuleGroup{},
 	}
 
-	origMap := map[string]rulefmt.RuleGroup{}
+	origMap := map[string]rwrulefmt.RuleGroup{}
 	for _, g := range original.Groups {
 		origMap[g.Name] = g
 	}

--- a/pkg/rules/compare.go
+++ b/pkg/rules/compare.go
@@ -14,9 +14,10 @@ import (
 )
 
 var (
-	errNameDiff     = errors.New("rule groups are named differently")
-	errIntervalDiff = errors.New("rule groups have different intervals")
-	errDiffRuleLen  = errors.New("rule groups have a different number of rules")
+	errNameDiff      = errors.New("rule groups are named differently")
+	errIntervalDiff  = errors.New("rule groups have different intervals")
+	errDiffRuleLen   = errors.New("rule groups have a different number of rules")
+	errDiffRWConfigs = errors.New("rule groups has different remote write configs")
 )
 
 // NamespaceState is used to denote the difference between the staged namespace
@@ -79,6 +80,16 @@ func CompareGroups(groupOne, groupTwo rwrulefmt.RuleGroup) error {
 
 	if len(groupOne.Rules) != len(groupTwo.Rules) {
 		return errDiffRuleLen
+	}
+
+	if len(groupOne.RWConfigs) != len(groupTwo.RWConfigs) {
+		return errDiffRWConfigs
+	}
+
+	for i := range groupOne.RWConfigs {
+		if groupOne.RWConfigs[i].URL != groupTwo.RWConfigs[i].URL {
+			return errDiffRWConfigs
+		}
 	}
 
 	for i := range groupOne.Rules {

--- a/pkg/rules/compare_test.go
+++ b/pkg/rules/compare_test.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"testing"
 
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -87,6 +88,200 @@ func Test_rulesEqual(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := rulesEqual(tt.a, tt.b); got != tt.want {
 				t.Errorf("rulesEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareGroups(t *testing.T) {
+	tests := []struct {
+		name        string
+		groupOne    rwrulefmt.RuleGroup
+		groupTwo    rwrulefmt.RuleGroup
+		expectedErr error
+	}{
+		{
+			name: "identical configs",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "different rule length",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+			},
+			expectedErr: errDiffRuleLen,
+		},
+		{
+			name: "identical rw configs",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{
+					{URL: "localhost"},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{
+					{URL: "localhost"},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "different rw config lengths",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{
+					{URL: "localhost"},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{
+					{URL: "localhost"},
+					{URL: "localhost"},
+				},
+			},
+			expectedErr: errDiffRWConfigs,
+		},
+		{
+			name: "different rw configs",
+			groupOne: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{
+					{URL: "localhost"},
+				},
+			},
+			groupTwo: rwrulefmt.RuleGroup{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "example_group",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record:      yaml.Node{Value: "one"},
+							Expr:        yaml.Node{Value: "up"},
+							Annotations: map[string]string{"a": "b", "c": "d"},
+							Labels:      nil,
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{
+					{URL: "localhost2"},
+				},
+			},
+			expectedErr: errDiffRWConfigs,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CompareGroups(tt.groupOne, tt.groupTwo); err != nil {
+				if err != tt.expectedErr {
+					t.Errorf("CompareGroups() error = %v, wantErr %v", err, tt.expectedErr)
+				}
 			}
 		})
 	}

--- a/pkg/rules/parser.go
+++ b/pkg/rules/parser.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/grafana/loki/pkg/ruler/manager"
 	log "github.com/sirupsen/logrus"
-
 	yaml "gopkg.in/yaml.v3"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 )
 
 const (
@@ -46,8 +47,16 @@ func ParseFiles(backend string, files []string) (map[string]RuleNamespace, error
 				return nil, errFileReadError
 			}
 
+			rwRgs := []rwrulefmt.RuleGroup{}
+			for _, rg := range rgs.Groups {
+				rwRgs = append(rwRgs, rwrulefmt.RuleGroup{
+					RuleGroup: rg,
+					RWConfigs: nil,
+				})
+			}
+
 			ns = &RuleNamespace{
-				Groups: rgs.Groups,
+				Groups: rwRgs,
 			}
 
 		default:

--- a/pkg/rules/parser_test.go
+++ b/pkg/rules/parser_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/prometheus/prometheus/pkg/rulefmt"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 )
 
 func TestParseFiles(t *testing.T) {
@@ -24,12 +26,14 @@ func TestParseFiles(t *testing.T) {
 			want: map[string]RuleNamespace{
 				"example_namespace": {
 					Namespace: "example_namespace",
-					Groups: []rulefmt.RuleGroup{
+					Groups: []rwrulefmt.RuleGroup{
 						{
-							Name: "example_rule_group",
-							Rules: []rulefmt.RuleNode{
-								{
-									// currently the tests only check length
+							RuleGroup: rulefmt.RuleGroup{
+								Name: "example_rule_group",
+								Rules: []rulefmt.RuleNode{
+									{
+										// currently the tests only check length
+									},
 								},
 							},
 						},
@@ -55,12 +59,14 @@ func TestParseFiles(t *testing.T) {
 			want: map[string]RuleNamespace{
 				"loki_basic": {
 					Namespace: "loki_basic",
-					Groups: []rulefmt.RuleGroup{
+					Groups: []rwrulefmt.RuleGroup{
 						{
-							Name: "testgrp2",
-							Rules: []rulefmt.RuleNode{
-								{
-									// currently the tests only check length
+							RuleGroup: rulefmt.RuleGroup{
+								Name: "testgrp2",
+								Rules: []rulefmt.RuleNode{
+									{
+										// currently the tests only check length
+									},
 								},
 							},
 						},

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -7,6 +7,8 @@ import (
 	"github.com/prometheus/prometheus/pkg/rulefmt"
 	"github.com/prometheus/prometheus/promql/parser"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 )
 
 // RuleNamespace is used to parse a slightly modified prometheus
@@ -17,7 +19,7 @@ type RuleNamespace struct {
 	Namespace string `yaml:"namespace,omitempty"`
 	Filepath  string `yaml:"-"`
 
-	Groups []rulefmt.RuleGroup `yaml:"groups"`
+	Groups []rwrulefmt.RuleGroup `yaml:"groups"`
 }
 
 // LintPromQLExpressions runs the `expr` from a rule through the PromQL parser and
@@ -212,7 +214,7 @@ func (r RuleNamespace) Validate() []error {
 }
 
 // ValidateRuleGroup validates a rulegroup
-func ValidateRuleGroup(g rulefmt.RuleGroup) []error {
+func ValidateRuleGroup(g rwrulefmt.RuleGroup) []error {
 	var errs []error
 	for i, r := range g.Rules {
 		for _, err := range r.Validate() {

--- a/pkg/rules/rwrulefmt/rulefmt.go
+++ b/pkg/rules/rwrulefmt/rulefmt.go
@@ -1,0 +1,17 @@
+package rwrulefmt
+
+import "github.com/prometheus/prometheus/pkg/rulefmt"
+
+// Wrapper around Prometheus rulefmt.
+
+// RuleGroup is a list of sequentially evaluated recording and alerting rules.
+type RuleGroup struct {
+	rulefmt.RuleGroup `yaml:",inline"`
+	// RWConfigs is used by the remote write forwarding ruler
+	RWConfigs []RemoteWriteConfig `yaml:"remote_write,omitempty"`
+}
+
+// RemoteWriteConfig is used to specify a remote write endpoint
+type RemoteWriteConfig struct {
+	URL string `json:"url,omitempty"`
+}


### PR DESCRIPTION
The easiest way to implement this is just to wrap the rulefmt.RuleGroup with a struct that inlines it and keep the rest of the logic as is. No validation is needed on the new field and since it's set to omitempty, it should not show up in marshalled/unmarshalled data unless explicitly set by the user.