### PR TITLE
feat: allow for loadgen to disable/enable queries/writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased / master
 
+* [ENHANCEMENT] Loadgen: Allow users to selectively disable query or write loadgen by leaving their respective URL configs empty. #95
+
 ## v0.3.2
 
 * [BUGFIX] Supports `rules lint` with LogQL: [#92](https://github.com/grafana/cortex-tools/pull/92).


### PR DESCRIPTION
This PR updates the `loadgen` command to disable writes/queries if their respective URLs have not been set. It will log when either has been disabled and return an error if neither has been enabled.