### PR TITLE
[BUGFIX] Do not panic if we're unable to contact GitHub for the `version` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## Unreleased
+
+* [BUGFIX] Do not panic if we're unable to contact GitHub for the `version` command. #103
+
 ## v0.4.1
 
 * [ENHANCEMENT] Upgrade the Go version used in build images and tests to golang 1.14.9 to match upstream Cortex. #104

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
+var (
 	errUnableToRetrieveLatestVersion = errors.New("unable to fetch the latest version from GitHub")
 )
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,11 +2,16 @@ package version
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/go-github/v32/github"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	errUnableToRetrieveLatestVersion = errors.New("unable to fetch the latest version from GitHub")
 )
 
 // Version defines the version for the binary, this is actually set by GoReleaser.
@@ -18,7 +23,12 @@ var Template = fmt.Sprintf("version %s\n", Version)
 // CheckLatest asks GitHub
 func CheckLatest() {
 	if Version != "master" {
-		latest := getLatestFromGitHub()
+		latest, err := getLatestFromGitHub()
+		if err != nil {
+			fmt.Println("unable to retrieve the latest version from GitHub")
+			return
+		}
+
 		version := Version
 		if latest != "" && (strings.TrimPrefix(latest, "v") != strings.TrimPrefix(version, "v")) {
 			fmt.Printf("A newer version of cortextool is available, please update to %s\n", latest)
@@ -28,14 +38,19 @@ func CheckLatest() {
 	}
 }
 
-func getLatestFromGitHub() string {
+func getLatestFromGitHub() (string, error) {
 	fmt.Print("checking latest version... ")
 	c := github.NewClient(nil)
-	resp, _, err := c.Repositories.GetLatestRelease(context.Background(), "grafana", "cortex-tools")
-
+	repoRelease, resp, err := c.Repositories.GetLatestRelease(context.Background(), "grafana", "cortex-tools")
 	if err != nil {
-		log.WithFields(log.Fields{"err": err}).Debugln("failed to retrieve latest version")
+		log.WithFields(log.Fields{"err": err}).Debugln("error while retrieving the latest version")
+		return "", errUnableToRetrieveLatestVersion
 	}
 
-	return *resp.TagName
+	if resp.StatusCode/100 != 2 {
+		log.WithFields(log.Fields{"status": resp.StatusCode}).Debugln("non-2xx status code while contacting the GitHub API")
+		return "", errUnableToRetrieveLatestVersion
+	}
+
+	return *repoRelease.TagName, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,7 +25,7 @@ func CheckLatest() {
 	if Version != "master" {
 		latest, err := getLatestFromGitHub()
 		if err != nil {
-			fmt.Println("unable to retrieve the latest version from GitHub")
+			fmt.Println(err)
 			return
 		}
 


### PR DESCRIPTION
Handles invalid responses from GitHub

Fixes #94 