### PR TITLE
fix: Purge timestamps older than deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 ## Unreleased
 
 * [FEATURE] Release `cortextool` via Homebrew for macOS #109
+* [FEATURE] Add new binary `e2ealerting` for measuring end to end alerting latency. #110
 * [BUGFIX] Do not panic if we're unable to contact GitHub for the `version` command. #107
+* [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
 
 ## v0.4.1
 

--- a/pkg/alerting/receiver.go
+++ b/pkg/alerting/receiver.go
@@ -194,7 +194,8 @@ func (r *Receiver) purgeTimestamps() {
 			r.mtx.Lock()
 			var deleted int
 			for t := range r.timestamps {
-				if deadline.Before(time.Unix(int64(t), 0)) {
+				// purge entry for the timestamp, when the deadline is after the timestamp t
+				if deadline.After(time.Unix(int64(t), 0)) {
 					delete(r.timestamps, t)
 					deleted++
 				}


### PR DESCRIPTION
This is a one off bug in our alert e2e measurement. It caused some invalid measurements being reported at around every purge interval.