### PR TITLE
Add --namespaces flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Unreleased
 
 * [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
+* [FEATURE] Add support for position rule-files arguments to `rules sync` and `rules diff` #125
+* [FEATURE] Add an allow-list of namespaces for `rules sync` and `rules diff` #125
 
 ## v0.5.0
 

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -159,7 +159,7 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 	loadRulesCmd.Arg("rule-files", "The rule files to check.").Required().ExistingFilesVar(&r.RuleFilesList)
 
 	// Diff Command
-	diffRulesCmd.Flag("namespaces", "comma-seperated list of namespaces to check during a diff. Cannot be used together with --ignored-namespaces.").StringVar(&r.Namespaces)
+	diffRulesCmd.Flag("namespaces", "comma-separated list of namespaces to check during a diff. Cannot be used together with --ignored-namespaces.").StringVar(&r.Namespaces)
 	diffRulesCmd.Flag("ignored-namespaces", "comma-separated list of namespaces to ignore during a diff. Cannot be used together with --namespaces.").StringVar(&r.IgnoredNamespaces)
 	diffRulesCmd.Flag("rule-files", "The rule files to check. Flag can be reused to load multiple files.").StringVar(&r.RuleFiles)
 	diffRulesCmd.Flag(
@@ -169,7 +169,7 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 	diffRulesCmd.Flag("disable-color", "disable colored output").BoolVar(&r.DisableColor)
 
 	// Sync Command
-	syncRulesCmd.Flag("namespaces", "comma-seperated list of namespaces to check during a diff. Cannot be used together with --ignored-namespaces.").StringVar(&r.Namespaces)
+	syncRulesCmd.Flag("namespaces", "comma-separated list of namespaces to check during a diff. Cannot be used together with --ignored-namespaces.").StringVar(&r.Namespaces)
 	syncRulesCmd.Flag("ignored-namespaces", "comma-separated list of namespaces to ignore during a sync. Cannot be used together with --namespaces.").StringVar(&r.IgnoredNamespaces)
 	syncRulesCmd.Flag("rule-files", "The rule files to check. Flag can be reused to load multiple files.").StringVar(&r.RuleFiles)
 	syncRulesCmd.Flag(
@@ -226,7 +226,7 @@ func (r *RuleCommand) setup(k *kingpin.ParseContext) error {
 
 func (r *RuleCommand) setupFiles() error {
 	if r.Namespaces != "" && r.IgnoredNamespaces != "" {
-		return errors.New("--namespaces and --ignored-namespaces cannot be set at the same time.")
+		return errors.New("--namespaces and --ignored-namespaces cannot be set at the same time")
 	}
 
 	// Set up ignored namespaces map for sync/diff command

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -159,6 +159,7 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 	loadRulesCmd.Arg("rule-files", "The rule files to check.").Required().ExistingFilesVar(&r.RuleFilesList)
 
 	// Diff Command
+	diffRulesCmd.Arg("rule-files", "The rule files to check.").ExistingFilesVar(&r.RuleFilesList)
 	diffRulesCmd.Flag("namespaces", "comma-separated list of namespaces to check during a diff. Cannot be used together with --ignored-namespaces.").StringVar(&r.Namespaces)
 	diffRulesCmd.Flag("ignored-namespaces", "comma-separated list of namespaces to ignore during a diff. Cannot be used together with --namespaces.").StringVar(&r.IgnoredNamespaces)
 	diffRulesCmd.Flag("rule-files", "The rule files to check. Flag can be reused to load multiple files.").StringVar(&r.RuleFiles)
@@ -169,6 +170,7 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 	diffRulesCmd.Flag("disable-color", "disable colored output").BoolVar(&r.DisableColor)
 
 	// Sync Command
+	syncRulesCmd.Arg("rule-files", "The rule files to check.").ExistingFilesVar(&r.RuleFilesList)
 	syncRulesCmd.Flag("namespaces", "comma-separated list of namespaces to check during a diff. Cannot be used together with --ignored-namespaces.").StringVar(&r.Namespaces)
 	syncRulesCmd.Flag("ignored-namespaces", "comma-separated list of namespaces to ignore during a sync. Cannot be used together with --namespaces.").StringVar(&r.IgnoredNamespaces)
 	syncRulesCmd.Flag("rule-files", "The rule files to check. Flag can be reused to load multiple files.").StringVar(&r.RuleFiles)
@@ -531,6 +533,10 @@ func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.Namesp
 	var err error
 	for _, ch := range changes {
 		for _, g := range ch.GroupsCreated {
+			if !r.shouldCheckNamespace(ch.Namespace) {
+				continue
+			}
+
 			log.WithFields(log.Fields{
 				"group":     g.Name,
 				"namespace": ch.Namespace,
@@ -542,6 +548,10 @@ func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.Namesp
 		}
 
 		for _, g := range ch.GroupsUpdated {
+			if !r.shouldCheckNamespace(ch.Namespace) {
+				continue
+			}
+
 			log.WithFields(log.Fields{
 				"group":     g.New.Name,
 				"namespace": ch.Namespace,
@@ -553,6 +563,10 @@ func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.Namesp
 		}
 
 		for _, g := range ch.GroupsDeleted {
+			if !r.shouldCheckNamespace(ch.Namespace) {
+				continue
+			}
+
 			log.WithFields(log.Fields{
 				"group":     g.Name,
 				"namespace": ch.Namespace,

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -396,7 +396,7 @@ func (r *RuleCommand) loadRules(k *kingpin.ParseContext) error {
 
 // shouldCheckNamespace returns whether the namespace should be checked according to the allowed and ignored namespaces
 func (r *RuleCommand) shouldCheckNamespace(namespace string) bool {
-       // when we have an allow list, only check those that we have explicitly defined.
+	// when we have an allow list, only check those that we have explicitly defined.
 	if r.namespacesMap != nil {
 		_, allowed := r.namespacesMap[namespace]
 		return allowed

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -396,6 +396,7 @@ func (r *RuleCommand) loadRules(k *kingpin.ParseContext) error {
 
 // shouldCheckNamespace returns whether the namespace should be checked according to the allowed and ignored namespaces
 func (r *RuleCommand) shouldCheckNamespace(namespace string) bool {
+       // when we have an allow list, only check those that we have explicitly defined.
 	if r.namespacesMap != nil {
 		_, allowed := r.namespacesMap[namespace]
 		return allowed


### PR DESCRIPTION
Fixes #124 

This:

- adds a seperate `--namespaces` flag seperate from `--ignore-namespaces`
- adds a check so that both cannot be used at the same time
- Adds a `shouldCheckNamespace` function
- Uses this function in diff, sync and executeChanges
- Adds positional file arguments to diff and sync as those were missing