### PR TITLE
Add ACL generate header command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ The Overrides Exporter allows to continuously export [per tenant configuration o
 [presets file]:./pkg/commands/testdata/presets.yaml
 [runtime-config]:https://cortexmetrics.io/docs/configuration/arguments/#runtime-configuration-file
 
+#### Generate ACL Headers
+
+This lets you generate the header which can then be used to enforce access control rules in GME / GrafanaCloud.
+
+```
+./cortextool acl generate-header --id=1234 --rule='{namespace="A"}'
+```
+
 ## chunktool
 
 This repo also contains the `chunktool`. A client meant to interact with chunks stored and indexed in cortex backends.

--- a/cmd/cortextool/main.go
+++ b/cmd/cortextool/main.go
@@ -18,6 +18,7 @@ var (
 	pushGateway              commands.PushGatewayConfig
 	loadgenCommand           commands.LoadgenCommand
 	remoteReadCommand        commands.RemoteReadCommand
+	aclCommand               commands.AccessControlCommand
 	overridesExporterCommand = commands.NewOverridesExporterCommand()
 )
 
@@ -31,6 +32,7 @@ func main() {
 	loadgenCommand.Register(app)
 	remoteReadCommand.Register(app)
 	overridesExporterCommand.Register(app)
+	aclCommand.Register(app)
 
 	app.Command("version", "Get the version of the cortextool CLI").Action(func(k *kingpin.ParseContext) error {
 		fmt.Print(version.Template)

--- a/pkg/commands/access_control.go
+++ b/pkg/commands/access_control.go
@@ -22,7 +22,7 @@ func (a *AccessControlCommand) Register(app *kingpin.Application) {
 
 	generateHeaderCmd := aclCmd.Command("generate-header", "Generate the header that needs to be passed to the datasource for setting ACLs.").Action(a.generateHeader)
 	generateHeaderCmd.Flag("id", "Cortex tenant ID, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.InstanceID)
-	generateHeaderCmd.Flag("rule", "The access control rules. Set it multiple times to set multiple rules.").Required().StringsVar(&a.ACLs)
+	generateHeaderCmd.Flag("rule", "The access control rules (Prometheus selectors). Set it multiple times to set multiple rules.").Required().StringsVar(&a.ACLs)
 }
 
 func (a *AccessControlCommand) generateHeader(k *kingpin.ParseContext) error {

--- a/pkg/commands/access_control.go
+++ b/pkg/commands/access_control.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/promql/parser"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+// AccessControlCommand is the kingpin command for ACLs.
+type AccessControlCommand struct {
+	InstanceID string
+	ACLs       []string
+}
+
+// Register is used to register the command to a parent command.
+func (a *AccessControlCommand) Register(app *kingpin.Application) {
+	aclCmd := app.Command("acl", "Generate and view ACL options in GrafanaCloud.")
+
+	generateHeaderCmd := aclCmd.Command("generate-header", "Generate the header that needs to be passed to the datasource for setting ACLs.").Action(a.generateHeader)
+	generateHeaderCmd.Flag("id", "Cortex tenant ID, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.InstanceID)
+	generateHeaderCmd.Flag("rule", "The access control rules. Set it multiple times to set multiple rules.").Required().StringsVar(&a.ACLs)
+}
+
+func (a *AccessControlCommand) generateHeader(k *kingpin.ParseContext) error {
+	for _, acl := range a.ACLs {
+		_, err := parser.ParseMetricSelector(acl)
+		if err != nil {
+			return errors.Wrapf(err, "cant parse metric selector for: %s", acl)
+		}
+	}
+
+	headerValues := []string{}
+	for _, acl := range a.ACLs {
+		headerValues = append(headerValues, fmt.Sprintf("%s:%s", a.InstanceID, url.PathEscape(acl)))
+	}
+
+	fmt.Println("The header to set:")
+	fmt.Println("X-Prom-Label-Policy:", strings.Join(headerValues, ","))
+
+	return nil
+}


### PR DESCRIPTION
It generates the header required for setting ACLs in GrafanaCloud beta.

Signed-off-by: Goutham Veeramachaneni <gouthamve@gmail.com>