### PR TITLE
Release cortextool v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # Changelog
 
+Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## Unreleased
 
 ## v0.6.0
 
-* [ENHANCEMENT] Handle trailing slashes in URLs on `cortextool`. #128
-* [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
+* [CHANGE] When using `rules` commands, cortex ruler API requests will now default to using the `/api/v1/` prefix. The `--use-legacy-routes` flag has been added to allow users to use the original `/api/prom/` routes. #99
 * [FEATURE] Add support for position rule-files arguments to `rules sync` and `rules diff` #125
 * [FEATURE] Add an allow-list of namespaces for `rules sync` and `rules diff` #125
-* [CHANGE] When using `rules` commands, cortex ruler API requests will now default to using the `/api/v1/` prefix. The `--use-legacy-routes` flag has been added to allow users to use the original `/api/prom/` routes. #99
+* [ENHANCEMENT] Handle trailing slashes in URLs on `cortextool`. #128
+* [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
 
 ## v0.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+## v0.6.0
+
 * [ENHANCEMENT] Handle trailing slashes in URLs on `cortextool`. #128
 * [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
 * [FEATURE] Add support for position rule-files arguments to `rules sync` and `rules diff` #125

--- a/changelogs/v0.6.0.md
+++ b/changelogs/v0.6.0.md
@@ -22,16 +22,3 @@ $ chmod a+x "/usr/local/bin/cortextool"
 # have fun :)
 $ cortextool --help
 ```
-
-## chunktool
-
-```console
-# download the binary (adapt os and arch as needed)
-$ curl -fSL -o "/usr/local/bin/chunktool" "https://github.com/grafana/cortex-tools/releases/download/v0.6.0/chunktool_0.6.0_linux_x86_64"
-
-# make it executable
-$ chmod a+x "/usr/local/bin/chunktool"
-
-# have fun :)
-$ chunktool --help
-```

--- a/changelogs/v0.6.0.md
+++ b/changelogs/v0.6.0.md
@@ -2,11 +2,11 @@
 
 ## Changes
 
-* [ENHANCEMENT] Handle trailing slashes in URLs on `cortextool`. #128
-* [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
+* [CHANGE] When using `rules` commands, cortex ruler API requests will now default to using the `/api/v1/` prefix. The `--use-legacy-routes` flag has been added to allow users to use the original `/api/prom/` routes. #99
 * [FEATURE] Add support for position rule-files arguments to `rules sync` and `rules diff` #125
 * [FEATURE] Add an allow-list of namespaces for `rules sync` and `rules diff` #125
-* [CHANGE] When using `rules` commands, cortex ruler API requests will now default to using the `/api/v1/` prefix. The `--use-legacy-routes` flag has been added to allow users to use the original `/api/prom/` routes. #99
+* [ENHANCEMENT] Handle trailing slashes in URLs on `cortextool`. #128
+* [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
 
 ## Installation
 

--- a/changelogs/v0.6.0.md
+++ b/changelogs/v0.6.0.md
@@ -1,0 +1,37 @@
+# v0.6.0 Release
+
+## Changes
+
+* [ENHANCEMENT] Handle trailing slashes in URLs on `cortextool`. #128
+* [BUGFIX] Fix inaccuracy in `e2ealerting` caused by invalid purging condition on timestamps. #117
+* [FEATURE] Add support for position rule-files arguments to `rules sync` and `rules diff` #125
+* [FEATURE] Add an allow-list of namespaces for `rules sync` and `rules diff` #125
+* [CHANGE] When using `rules` commands, cortex ruler API requests will now default to using the `/api/v1/` prefix. The `--use-legacy-routes` flag has been added to allow users to use the original `/api/prom/` routes. #99
+
+## Installation
+
+## cortextool
+
+```console
+# download the binary (adapt os and arch as needed)
+$ curl -fSL -o "/usr/local/bin/cortextool" "https://github.com/grafana/cortex-tools/releases/download/v0.6.0/cortextool_0.6.0_linux_x86_64"
+
+# make it executable
+$ chmod a+x "/usr/local/bin/cortextool"
+
+# have fun :)
+$ cortextool --help
+```
+
+## chunktool
+
+```console
+# download the binary (adapt os and arch as needed)
+$ curl -fSL -o "/usr/local/bin/chunktool" "https://github.com/grafana/cortex-tools/releases/download/v0.6.0/chunktool_0.6.0_linux_x86_64"
+
+# make it executable
+$ chmod a+x "/usr/local/bin/chunktool"
+
+# have fun :)
+$ chunktool --help
+```


### PR DESCRIPTION
Release notes for a new version of `cortextool`. Decided to a major bump due to the default path change for the rules API.