### PR TITLE
Add format for rules list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## Unreleased
 
+* [ENHANCEMENT] Add format for rules list command. #130
+
 ## v0.6.1
 
 * [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected. #133

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -313,7 +313,7 @@ func (r *RuleCommand) listRules(k *kingpin.ParseContext) error {
 	}
 
 	p := printer.New(r.DisableColor)
-	return p.PrintRuleSet(rules, r.Format)
+	return p.PrintRuleSet(rules, r.Format, os.Stdout)
 }
 
 func (r *RuleCommand) printRules(k *kingpin.ParseContext) error {

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -1,0 +1,97 @@
+package printer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/alecthomas/chroma/quick"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
+)
+
+func TestPrintRuleSet(t *testing.T) {
+	giveRules := map[string][]rwrulefmt.RuleGroup{
+		"test-namespace-1": []rwrulefmt.RuleGroup{
+			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-a"}},
+			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-b"}},
+		},
+		"test-namespace-2": []rwrulefmt.RuleGroup{
+			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-c"}},
+			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-d"}},
+		},
+	}
+
+	wantJSONOutput := `[{"namespace":"test-namespace-1","rulegroup":"test-rulegroup-a"},{"namespace":"test-namespace-1","rulegroup":"test-rulegroup-b"},{"namespace":"test-namespace-2","rulegroup":"test-rulegroup-c"},{"namespace":"test-namespace-2","rulegroup":"test-rulegroup-d"}]`
+	var wantColoredJSONBuffer bytes.Buffer
+	err := quick.Highlight(&wantColoredJSONBuffer, wantJSONOutput, "json", "terminal", "swapoff")
+	require.NoError(t, err)
+
+	wantTabOutput := `Namespace        | Rule Group
+test-namespace-1 | test-rulegroup-a
+test-namespace-1 | test-rulegroup-b
+test-namespace-2 | test-rulegroup-c
+test-namespace-2 | test-rulegroup-d
+`
+
+	wantYAMLOutput := `- namespace: test-namespace-1
+  rulegroup: test-rulegroup-a
+- namespace: test-namespace-1
+  rulegroup: test-rulegroup-b
+- namespace: test-namespace-2
+  rulegroup: test-rulegroup-c
+- namespace: test-namespace-2
+  rulegroup: test-rulegroup-d
+`
+	var wantColoredYAMLBuffer bytes.Buffer
+	err = quick.Highlight(&wantColoredYAMLBuffer, wantYAMLOutput, "yaml", "terminal", "swapoff")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		giveDisableColor bool
+		giveFormat       string
+		wantOutput       string
+	}{
+		{
+			name:             "prints colorless json",
+			giveDisableColor: true,
+			giveFormat:       "json",
+			wantOutput:       wantJSONOutput,
+		},
+		{
+			name:       "prints colorful json",
+			giveFormat: "json",
+			wantOutput: wantColoredJSONBuffer.String(),
+		},
+		{
+			name:             "prints colorless yaml",
+			giveDisableColor: true,
+			giveFormat:       "yaml",
+			wantOutput:       wantYAMLOutput,
+		},
+		{
+			name:       "prints colorful yaml",
+			giveFormat: "yaml",
+			wantOutput: wantColoredYAMLBuffer.String(),
+		},
+		{
+			name:             "defaults to tabwriter",
+			giveDisableColor: true,
+			wantOutput:       wantTabOutput,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(tst *testing.T) {
+			var b bytes.Buffer
+
+			p := New(tt.giveDisableColor)
+			p.PrintRuleSet(giveRules, tt.giveFormat, &b)
+
+			assert.Equal(tst, tt.wantOutput, b.String())
+		})
+	}
+}

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -14,11 +14,11 @@ import (
 
 func TestPrintRuleSet(t *testing.T) {
 	giveRules := map[string][]rwrulefmt.RuleGroup{
-		"test-namespace-1": []rwrulefmt.RuleGroup{
+		"test-namespace-1": {
 			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-a"}},
 			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-b"}},
 		},
-		"test-namespace-2": []rwrulefmt.RuleGroup{
+		"test-namespace-2": {
 			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-c"}},
 			{RuleGroup: rulefmt.RuleGroup{Name: "test-rulegroup-d"}},
 		},

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -89,8 +89,9 @@ test-namespace-2 | test-rulegroup-d
 			var b bytes.Buffer
 
 			p := New(tt.giveDisableColor)
-			p.PrintRuleSet(giveRules, tt.giveFormat, &b)
+			err := p.PrintRuleSet(giveRules, tt.giveFormat, &b)
 
+			require.NoError(tst, err)
 			assert.Equal(tst, tt.wantOutput, b.String())
 		})
 	}


### PR DESCRIPTION
This adds json, yaml, and table (default, previous behavior) to the `--format` flag for the `cortextool rules list` command. This allows the output to be more easily parseable by command-line tools like `jq` and `yq`.