### PR TITLE
[cortextool][bugfix] Deference the endpoint to avoid modifiying it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## v0.6.1
 
-* [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected.
+* [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected. #133
 
 ## v0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## Unreleased
 
+## v0.6.1
+
+* [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected.
+
 ## v0.6.0
 
 * [CHANGE] When using `rules` commands, cortex ruler API requests will now default to using the `/api/v1/` prefix. The `--use-legacy-routes` flag has been added to allow users to use the original `/api/prom/` routes. #99

--- a/changelogs/v0.6.1.md
+++ b/changelogs/v0.6.1.md
@@ -2,7 +2,7 @@
 
 ## Changes
 
-* [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected.
+* [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected. #133
 
 ## Installation
 

--- a/changelogs/v0.6.1.md
+++ b/changelogs/v0.6.1.md
@@ -1,0 +1,20 @@
+# v0.6.1 Release
+
+## Changes
+
+* [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected.
+
+## Installation
+
+## cortextool
+
+```console
+# download the binary (adapt os and arch as needed)
+$ curl -fSL -o "/usr/local/bin/cortextool" "https://github.com/grafana/cortex-tools/releases/download/v0.6.1/cortextool_0.6.1_linux_x86_64"
+
+# make it executable
+$ chmod a+x "/usr/local/bin/cortextool"
+
+# have fun :)
+$ cortextool --help
+```

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -102,7 +102,7 @@ func (r *CortexClient) Query(ctx context.Context, query string) (*http.Response,
 }
 
 func (r *CortexClient) doRequest(path, method string, payload []byte) (*http.Response, error) {
-	req, err := buildRequest(path, method, r.endpoint, payload)
+	req, err := buildRequest(path, method, *r.endpoint, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func checkResponse(r *http.Response) error {
 	return errors.New("failed request to the cortex api")
 }
 
-func buildRequest(p, m string, endpoint *url.URL, payload []byte) (*http.Request, error) {
+func buildRequest(p, m string, endpoint url.URL, payload []byte) (*http.Request, error) {
 	endpoint.Path = path.Join(endpoint.Path, p)
 	return http.NewRequest(m, endpoint.String(), bytes.NewBuffer(payload))
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -44,7 +44,7 @@ func TestTrailingSlash(t *testing.T) {
 			url, err := url.Parse(tt.url)
 			require.NoError(t, err)
 
-			req, err := buildRequest(tt.path, tt.method, url, []byte{})
+			req, err := buildRequest(tt.path, tt.method, *url, []byte{})
 			require.NoError(t, err)
 			require.Equal(t, tt.resultURL, req.URL.String())
 		})


### PR DESCRIPTION
Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected.