### PR TITLE
Add remote-read commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## Unreleased
 
+* [FEATURE] Add `remote-read` commands to investigate series through the remote-read API. #134
+   - `remote-read export`: Export metrics remote read series into a local TSDB.
+   - `remote-read dump`: Dump remote read series.
+   - `remote-read stats`: Show statistic of remote read series.
+
 ## v0.6.1
 
 * [BUGFIX] Fix `cortextool` generating the wrong paths when executing multiple calls to the cortex API. In particular, commands like `load`, `sync` were affected. #133

--- a/cmd/cortextool/main.go
+++ b/cmd/cortextool/main.go
@@ -17,6 +17,7 @@ var (
 	logConfig                commands.LoggerConfig
 	pushGateway              commands.PushGatewayConfig
 	loadgenCommand           commands.LoadgenCommand
+	remoteReadCommand        commands.RemoteReadCommand
 	overridesExporterCommand = commands.NewOverridesExporterCommand()
 )
 
@@ -28,6 +29,7 @@ func main() {
 	ruleCommand.Register(app)
 	pushGateway.Register(app)
 	loadgenCommand.Register(app)
+	remoteReadCommand.Register(app)
 	overridesExporterCommand.Register(app)
 
 	app.Command("version", "Get the version of the cortextool CLI").Action(func(k *kingpin.ParseContext) error {

--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -1,0 +1,171 @@
+package backfill
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/alecthomas/units"
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+)
+
+// copied from https://github.com/prometheus/prometheus/blob/2f54aa060484a9a221eb227e1fb917ae66051c76/cmd/promtool/tsdb.go#L361-L398
+
+func printBlocks(blocks []tsdb.BlockReader, writeHeader, humanReadable bool, output io.Writer) {
+	tw := tabwriter.NewWriter(output, 13, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	if writeHeader {
+		fmt.Fprintln(tw, "BLOCK ULID\tMIN TIME\tMAX TIME\tDURATION\tNUM SAMPLES\tNUM CHUNKS\tNUM SERIES\tSIZE")
+	}
+
+	for _, b := range blocks {
+		meta := b.Meta()
+
+		fmt.Fprintf(tw,
+			"%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+			meta.ULID,
+			getFormatedTime(meta.MinTime, humanReadable),
+			getFormatedTime(meta.MaxTime, humanReadable),
+			time.Duration(meta.MaxTime-meta.MinTime)*time.Millisecond,
+			meta.Stats.NumSamples,
+			meta.Stats.NumChunks,
+			meta.Stats.NumSeries,
+			getFormatedBytes(b.Size(), humanReadable),
+		)
+	}
+}
+
+func getFormatedTime(timestamp int64, humanReadable bool) string {
+	if humanReadable {
+		return time.Unix(timestamp/1000, 0).UTC().String()
+	}
+	return strconv.FormatInt(timestamp, 10)
+}
+
+func getFormatedBytes(bytes int64, humanReadable bool) string {
+	if humanReadable {
+		return units.Base2Bytes(bytes).String()
+	}
+	return strconv.FormatInt(bytes, 10)
+}
+
+type Iterator interface {
+	Next() error
+	Sample() (ts int64, v float64)
+	Labels() (l labels.Labels)
+}
+
+type IteratorCreator func() Iterator
+
+// this is adapted from  https://github.com/prometheus/prometheus/blob/2f54aa060484a9a221eb227e1fb917ae66051c76/cmd/promtool/backfill.go#L68-L171
+func CreateBlocks(input IteratorCreator, mint, maxt int64, maxSamplesInAppender int, outputDir string, humanReadable bool, output io.Writer) (returnErr error) {
+	blockDuration := tsdb.DefaultBlockDuration
+	mint = blockDuration * (mint / blockDuration)
+
+	db, err := tsdb.OpenDBReadOnly(outputDir, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		var mErr tsdb_errors.MultiError
+		mErr.Add(returnErr)
+		mErr.Add(db.Close())
+		returnErr = mErr.Err()
+	}()
+
+	var wroteHeader bool
+
+	for t := mint; t <= maxt; t = t + blockDuration {
+		err := func() error {
+			w, err := tsdb.NewBlockWriter(log.NewNopLogger(), outputDir, blockDuration)
+			if err != nil {
+				return errors.Wrap(err, "block writer")
+			}
+			defer func() {
+				var mErr tsdb_errors.MultiError
+				mErr.Add(err)
+				mErr.Add(w.Close())
+				err = mErr.Err()
+			}()
+
+			ctx := context.Background()
+			app := w.Appender(ctx)
+			i := input()
+			tsUpper := t + blockDuration
+			samplesCount := 0
+			for {
+				err := i.Next()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					return errors.Wrap(err, "input")
+				}
+
+				ts, v := i.Sample()
+				if ts < t || ts >= tsUpper {
+					continue
+				}
+
+				l := i.Labels()
+				if _, err := app.Add(i.Labels(), ts, v); err != nil {
+					return errors.Wrap(err, fmt.Sprintf("add sample for metric=%s ts=%s value=%f", l, model.Time(ts).Time().Format(time.RFC3339Nano), v))
+				}
+
+				samplesCount++
+				if samplesCount < maxSamplesInAppender {
+					continue
+				}
+
+				// If we arrive here, the samples count is greater than the maxSamplesInAppender.
+				// Therefore the old appender is committed and a new one is created.
+				// This prevents keeping too many samples lined up in an appender and thus in RAM.
+				if err := app.Commit(); err != nil {
+					return errors.Wrap(err, "commit")
+				}
+
+				app = w.Appender(ctx)
+				samplesCount = 0
+			}
+
+			if err := app.Commit(); err != nil {
+				return errors.Wrap(err, "commit")
+			}
+
+			block, err := w.Flush(ctx)
+			if err != nil && !strings.Contains(err.Error(), "no series appended, aborting") {
+				return errors.Wrap(err, "flush")
+			}
+
+			blocks, err := db.Blocks()
+			if err != nil {
+				return errors.Wrap(err, "get blocks")
+			}
+			for _, b := range blocks {
+				if b.Meta().ULID == block {
+					printBlocks([]tsdb.BlockReader{b}, !wroteHeader, humanReadable, output)
+					wroteHeader = true
+					break
+				}
+			}
+
+			return nil
+		}()
+
+		if err != nil {
+			return errors.Wrap(err, "process blocks")
+		}
+	}
+	return nil
+
+}

--- a/pkg/commands/remote_read.go
+++ b/pkg/commands/remote_read.go
@@ -1,0 +1,441 @@
+package commands
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/storage/remote"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/grafana/cortex-tools/pkg/backfill"
+)
+
+type RemoteReadCommand struct {
+	address        string
+	remoteReadPath string
+
+	tenantID string
+	apiKey   string
+
+	readTimeout time.Duration
+	tsdbPath    string
+
+	selector string
+	from     string
+	to       string
+}
+
+func (c *RemoteReadCommand) Register(app *kingpin.Application) {
+	remoteReadCmd := app.Command("remote-read", "Inspect stored series in Cortex using the remote read API.")
+	exportCmd := remoteReadCmd.Command("export", "Export metrics remote read series into a local TSDB.").Action(c.export)
+	dumpCmd := remoteReadCmd.Command("dump", "Dump remote read series.").Action(c.dump)
+	statsCmd := remoteReadCmd.Command("stats", "Show statistic of remote read series.").Action(c.stats)
+
+	now := time.Now()
+	for _, cmd := range []*kingpin.CmdClause{exportCmd, dumpCmd, statsCmd} {
+		cmd.Flag("address", "Address of the cortex cluster, alternatively set $CORTEX_ADDRESS.").
+			Envar("CORTEX_ADDRESS").
+			Required().
+			StringVar(&c.address)
+		cmd.Flag("remote-read-path", "Path of the remote read endpoint.").
+			Default("/prometheus/api/v1/read").
+			StringVar(&c.remoteReadPath)
+		cmd.Flag("id", "Cortex tenant id, alternatively set $CORTEX_TENANT_ID.").
+			Envar("CORTEX_TENANT_ID").
+			Default("").
+			StringVar(&c.tenantID)
+		cmd.Flag("key", "Api key to use when contacting cortex, alternatively set $CORTEX_API_KEY.").
+			Envar("CORTEX_API_KEY").
+			Default("").
+			StringVar(&c.apiKey)
+		cmd.Flag("read-timeout", "timeout for read requests").
+			Default("30s").
+			DurationVar(&c.readTimeout)
+
+		cmd.Flag("selector", `PromQL selector to filter metrics on. To return all metrics '{__name__!=""}' can be used.`).
+			Default("up").
+			StringVar(&c.selector)
+
+		cmd.Flag("from", "Start of the time window to select metrics.").
+			Default(now.Add(-time.Hour).Format(time.RFC3339)).
+			StringVar(&c.from)
+		cmd.Flag("to", "End of the time window to select metrics.").
+			Default(now.Format(time.RFC3339)).
+			StringVar(&c.to)
+	}
+
+	exportCmd.Flag("tsdb-path", "Path to the folder where to store the TSDB blocks, if not set a new directory in $TEMP is created.").
+		Default("").
+		StringVar(&c.tsdbPath)
+}
+
+type setTenantIDTransport struct {
+	http.RoundTripper
+	tenantID string
+}
+
+func (s *setTenantIDTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("X-Scope-OrgID", s.tenantID)
+	return s.RoundTripper.RoundTrip(req)
+}
+
+type timeSeriesIterator struct {
+	posSeries int
+	posSample int
+	ts        []*prompb.TimeSeries
+
+	// labels slice is reused across samples within a series
+	labels          labels.Labels
+	labelsSeriesPos int
+}
+
+func newTimeSeriesIterator(ts []*prompb.TimeSeries) *timeSeriesIterator {
+	return &timeSeriesIterator{
+		posSeries: 0,
+		posSample: -1,
+
+		// ensure we are not pointing to a valid slice position
+		labelsSeriesPos: -1,
+
+		ts: ts,
+	}
+
+}
+
+func (i *timeSeriesIterator) Next() error {
+	if i.posSeries >= len(i.ts) {
+		return io.EOF
+	}
+
+	i.posSample++
+
+	if i.posSample >= len(i.ts[i.posSeries].Samples) {
+		i.posSample = -1
+		i.posSeries++
+		return i.Next()
+	}
+
+	return nil
+}
+
+func (i *timeSeriesIterator) Labels() (l labels.Labels) {
+	// if it's the same label as previously return it
+	if i.posSeries == i.labelsSeriesPos {
+		return i.labels
+	}
+
+	series := i.ts[i.posSeries]
+	i.labels = make(labels.Labels, len(series.Labels))
+	for posLabel := range series.Labels {
+		i.labels[posLabel].Name = series.Labels[posLabel].Name
+		i.labels[posLabel].Value = series.Labels[posLabel].Value
+	}
+	i.labelsSeriesPos = i.posSeries
+	return i.labels
+}
+
+func (i *timeSeriesIterator) Sample() (ts int64, v float64) {
+	series := i.ts[i.posSeries]
+	sample := series.Samples[i.posSample]
+
+	//sample.GetValue()
+	return sample.GetTimestamp(), sample.GetValue()
+}
+
+// this is adapted from Go 1.15 for older versions
+// TODO: Reuse upstream once that version is common
+func redactedURL(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+
+	ru := *u
+	if _, has := ru.User.Password(); has {
+		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
+	}
+	return ru.String()
+}
+
+func (c *RemoteReadCommand) readClient() (remote.ReadClient, error) {
+	// validate inputs
+	addressURL, err := url.Parse(c.address)
+	if err != nil {
+		return nil, err
+	}
+
+	addressURL.Path = filepath.Join(
+		addressURL.Path,
+		c.remoteReadPath,
+	)
+
+	// build client
+	readClient, err := remote.NewReadClient("remote-read", &remote.ClientConfig{
+		URL:     &config_util.URL{URL: addressURL},
+		Timeout: model.Duration(c.readTimeout),
+		HTTPClientConfig: config_util.HTTPClientConfig{
+			BasicAuth: &config_util.BasicAuth{
+				Username: c.tenantID,
+				Password: config_util.Secret(c.apiKey),
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// if tenant ID is set, add a tenant ID header to every request
+	if c.tenantID != "" {
+		client, ok := readClient.(*remote.Client)
+		if !ok {
+			return nil, fmt.Errorf("unexpected type %T", readClient)
+		}
+		client.Client.Transport = &setTenantIDTransport{
+			RoundTripper: client.Client.Transport,
+			tenantID:     c.tenantID,
+		}
+	}
+
+	log.Infof("Created remote read client using endpoint '%s'", redactedURL(addressURL))
+
+	return readClient, nil
+}
+
+// prepare() validates the input and prepares the client to query remote read endpoints
+func (c *RemoteReadCommand) prepare() (query func(context.Context) ([]*prompb.TimeSeries, error), from, to time.Time, err error) {
+	from, err = time.Parse(time.RFC3339, c.from)
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, fmt.Errorf("error parsing from: '%s' value: %w", c.from, err)
+	}
+
+	to, err = time.Parse(time.RFC3339, c.to)
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, fmt.Errorf("error parsing to: '%s' value: %w", c.to, err)
+	}
+
+	matchers, err := parser.ParseMetricSelector(c.selector)
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, err
+	}
+
+	readClient, err := c.readClient()
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, err
+	}
+
+	pbQuery, err := remote.ToQuery(
+		int64(model.TimeFromUnixNano(from.UnixNano())),
+		int64(model.TimeFromUnixNano(to.UnixNano())),
+		matchers,
+		nil,
+	)
+	if err != nil {
+		return nil, time.Time{}, time.Time{}, err
+	}
+
+	return func(ctx context.Context) ([]*prompb.TimeSeries, error) {
+		log.Infof("Querying time from=%s to=%s with selector=%s", from.Format(time.RFC3339), to.Format(time.RFC3339), c.selector)
+		resp, err := readClient.Read(ctx, pbQuery)
+		if err != nil {
+			return nil, err
+		}
+
+		return resp.Timeseries, nil
+
+	}, from, to, nil
+}
+
+func (c *RemoteReadCommand) dump(k *kingpin.ParseContext) error {
+	query, _, _, err := c.prepare()
+	if err != nil {
+		return err
+	}
+
+	timeseries, err := query(context.Background())
+	if err != nil {
+		return nil
+	}
+
+	iterator := newTimeSeriesIterator(timeseries)
+	for {
+		err := iterator.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+
+		l := iterator.Labels()
+		ts, v := iterator.Sample()
+		comment := ""
+		if value.IsStaleNaN(v) {
+			comment = " # StaleNaN"
+		}
+		fmt.Printf("%s %g %d%s\n", l, v, ts, comment)
+	}
+
+	return nil
+}
+
+func (c *RemoteReadCommand) stats(k *kingpin.ParseContext) error {
+	query, _, _, err := c.prepare()
+	if err != nil {
+		return err
+	}
+
+	timeseries, err := query(context.Background())
+	if err != nil {
+		return nil
+	}
+
+	num := struct {
+		Samples int64
+		Series  map[string]struct{}
+
+		NaNValues      int64
+		StaleNaNValues int64
+
+		MinT model.Time
+		MaxT model.Time
+	}{
+		Series: make(map[string]struct{}),
+	}
+
+	iterator := newTimeSeriesIterator(timeseries)
+	for {
+		err := iterator.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
+		}
+		num.Samples++
+		num.Series[iterator.Labels().String()] = struct{}{}
+
+		ts, v := iterator.Sample()
+
+		if int64(num.MaxT) < ts {
+			num.MaxT = model.Time(ts)
+		}
+		if num.MinT == 0 || int64(num.MinT) > ts {
+			num.MinT = model.Time(ts)
+		}
+
+		if math.IsNaN(v) {
+			num.NaNValues++
+		}
+		if value.IsStaleNaN(v) {
+			num.StaleNaNValues++
+		}
+	}
+
+	output := bytes.NewBuffer(nil)
+	tw := tabwriter.NewWriter(output, 13, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "MIN TIME\tMAX TIME\tDURATION\tNUM SAMPLES\tNUM SERIES\tNUM STALE NAN VALUES\tNUM NAN VALUES")
+
+	fmt.Fprintf(
+		tw,
+		"%s\t%s\t%s\t%d\t%d\t%d\t%d\n",
+		num.MinT.Time().UTC().String(),
+		num.MaxT.Time().UTC().String(),
+		num.MaxT.Sub(num.MinT),
+		num.Samples,
+		len(num.Series),
+		num.StaleNaNValues,
+		num.NaNValues,
+	)
+
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	for _, line := range strings.Split(output.String(), "\n") {
+		if len(line) != 0 {
+			log.Info(line)
+		}
+	}
+
+	return nil
+}
+
+func (c *RemoteReadCommand) export(k *kingpin.ParseContext) error {
+	query, from, to, err := c.prepare()
+	if err != nil {
+		return err
+	}
+
+	if c.tsdbPath == "" {
+		c.tsdbPath, err = ioutil.TempDir("", "cortextool-tsdb")
+		if err != nil {
+			return err
+		}
+		log.Infof("Created TSDB in path '%s'", c.tsdbPath)
+	} else {
+		if _, err := os.Stat(c.tsdbPath); err != nil && os.IsNotExist(err) {
+			if err = os.Mkdir(c.tsdbPath, 0755); err != nil {
+				return err
+			}
+			log.Infof("Created TSDB in path '%s'", c.tsdbPath)
+		}
+		log.Infof("Using existing TSDB in path '%s'", c.tsdbPath)
+	}
+
+	mint := model.TimeFromUnixNano(from.UnixNano())
+	maxt := model.TimeFromUnixNano(to.UnixNano())
+
+	timeseries, err := query(context.Background())
+	if err != nil {
+		return err
+	}
+
+	iterator := func() backfill.Iterator {
+		return newTimeSeriesIterator(timeseries)
+	}
+
+	pipeR, pipeW := io.Pipe()
+	go func() {
+		scanner := bufio.NewScanner(pipeR)
+		for scanner.Scan() {
+			log.Info(scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			log.Error("reading block status:", err)
+		}
+	}()
+	defer pipeR.Close()
+
+	log.Infof("Store TSDB blocks in '%s'", c.tsdbPath)
+	if err := backfill.CreateBlocks(iterator, int64(mint), int64(maxt), 1000, c.tsdbPath, true, pipeW); err != nil {
+		return err
+	}
+
+	// ensure that tsdb directory has WAL, otherwise 'promtool tsdb dump' fails
+	walPath := filepath.Join(c.tsdbPath, "wal")
+	if _, err := os.Stat(walPath); err != nil && os.IsNotExist(err) {
+		if err := os.Mkdir(walPath, 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/commands/remote_read_test.go
+++ b/pkg/commands/remote_read_test.go
@@ -1,0 +1,146 @@
+package commands
+
+import (
+	"io"
+	"testing"
+
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeSeriesIterator(t *testing.T) {
+
+	for _, tc := range []struct {
+		name               string
+		timeSeries         []*prompb.TimeSeries
+		expectedLabels     []string
+		expectedTimestamps []int64
+		expectedValues     []float64
+	}{
+		{
+			name: "empty time series",
+		},
+		{
+			name: "simple",
+			timeSeries: []*prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: "up",
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Value:     1.23,
+							Timestamp: 1000,
+						},
+						{
+							Value:     1.24,
+							Timestamp: 2000,
+						},
+					},
+				},
+			},
+			expectedLabels: []string{
+				`{__name__="up"}`,
+				`{__name__="up"}`,
+			},
+			expectedTimestamps: []int64{
+				1000,
+				2000,
+			},
+			expectedValues: []float64{
+				1.23,
+				1.24,
+			},
+		},
+		{
+			name: "edge-cases",
+			timeSeries: []*prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{},
+					Samples: []prompb.Sample{
+						{
+							Value:     1.23,
+							Timestamp: 1000,
+						},
+						{
+							Value:     1.24,
+							Timestamp: 2000,
+						},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: "upper",
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Value:     2.34,
+							Timestamp: 1050,
+						},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: "uppest",
+						},
+					},
+					Samples: []prompb.Sample{},
+				},
+			},
+			expectedLabels: []string{
+				`{}`,
+				`{}`,
+				`{__name__="upper"}`,
+			},
+			expectedTimestamps: []int64{
+				1000,
+				2000,
+				1050,
+			},
+			expectedValues: []float64{
+				1.23,
+				1.24,
+				2.34,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+
+			iter := newTimeSeriesIterator(tc.timeSeries)
+
+			var (
+				labels     []string
+				timestamps []int64
+				values     []float64
+			)
+
+			for {
+				err := iter.Next()
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					assert.NoError(t, err, "unexpected error")
+					break
+				}
+
+				labels = append(labels, iter.Labels().String())
+				ts, v := iter.Sample()
+				timestamps = append(timestamps, ts)
+				values = append(values, v)
+			}
+
+			assert.Equal(t, tc.expectedLabels, labels)
+			assert.Equal(t, tc.expectedTimestamps, timestamps)
+			assert.Equal(t, tc.expectedValues, values)
+		})
+	}
+
+}


### PR DESCRIPTION
The remote-read commands allow to investigate series through the remote-read API:

 * `remote-read export`: Export metrics remote read series into a local
 TSDB.
 * `remote-read dump`: Dump remote read series.
 * `remote-read stats`: Show statistic of remote read series.

Signed-off-by: Christian Simon <simon@swine.de>