### PR TITLE
uses legacy routes when loki backend is enabled

### DIFF
--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -222,6 +222,11 @@ func (r *RuleCommand) setup(k *kingpin.ParseContext) error {
 		ruleLoadSuccessTimestamp,
 	)
 
+	// Loki's non-legacy route does not match Cortex, but the legacy one does.
+	if r.Backend == rules.LokiBackend {
+		r.ClientConfig.UseLegacyRoutes = true
+	}
+
 	cli, err := client.New(r.ClientConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
Just found out the recent versions do not work against Loki endpoints anymore. I pulled `0.5.0` to check (it was the last version I released):

```
$ cortextool rules print --backend=loki --log.level=debug
INFO[0000] log level set to debug
DEBU[0000] sending request to cortex api                 method=GET url="https://loki-dev-us-central1.grafana.net/api/v1/rules"
DEBU[0000] checking response                             status="404 Not Found"
DEBU[0000] resource not found                            fields.msg="request failed with response body 404 page not found\n" status="404 Not Found"
INFO[0000] no rule groups currently exist for this user

$ /tmp/cortextool-0.5 rules print --backend=loki --log.level=debug
INFO[0000] log level set to debug
DEBU[0000] sending request to cortex api                 method=GET url="https://loki-dev-us-central1.grafana.net/api/prom/rules"
DEBU[0000] checking response                             status="200 OK"
```

The recent versions now use `/api/v1/rules`, which Loki does not support (it uses `/loki/api/v1/rules`). However, Loki still supports legacy routes, so I made the quick and hopefully forward compatible fix to use legacy routes when the Loki backend is enabled.

Afterwards:
```
$ cortextool rules print --backend=loki --log.level=debug
INFO[0000] log level set to debug
DEBU[0000] sending request to cortex api                 method=GET url="https://loki-dev-us-central1.grafana.net/api/prom/rules"
DEBU[0000] checking response                             status="200 OK"
```