### PR TITLE
fix: Ensure special characters in rule and namespace names are handled correctly

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -170,6 +170,16 @@ func checkResponse(r *http.Response) error {
 }
 
 func buildRequest(p, m string, endpoint url.URL, payload []byte) (*http.Request, error) {
-	endpoint.Path = path.Join(endpoint.Path, p)
+	// parse path parameter again (as it already contains escaped path information
+	pURL, err := url.Parse(p)
+	if err != nil {
+		return nil, err
+	}
+
+	// if path or endpoint contains escaping that requires RawPath to be populated, also join rawPath
+	if pURL.RawPath != "" || endpoint.RawPath != "" {
+		endpoint.RawPath = path.Join(endpoint.EscapedPath(), pURL.EscapedPath())
+	}
+	endpoint.Path = path.Join(endpoint.Path, pURL.Path)
 	return http.NewRequest(m, endpoint.String(), bytes.NewBuffer(payload))
 }

--- a/pkg/client/rules_test.go
+++ b/pkg/client/rules_test.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCortexClient_X(t *testing.T) {
+	requestCh := make(chan *http.Request, 1)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCh <- r
+		fmt.Fprintln(w, "hello")
+	}))
+	defer ts.Close()
+
+	client, err := New(Config{
+		Address: ts.URL,
+		ID:      "my-id",
+		Key:     "my-key",
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		test       string
+		namespace  string
+		name       string
+		expURLPath string
+	}{
+		{
+			test:       "regular-characters",
+			namespace:  "my-namespace",
+			name:       "my-name",
+			expURLPath: "/api/v1/rules/my-namespace/my-name",
+		},
+		{
+			test:       "special-characters-spaces",
+			namespace:  "My: Namespace",
+			name:       "My: Name",
+			expURLPath: "/api/v1/rules/My:%20Namespace/My:%20Name",
+		},
+		{
+			test:       "special-characters-slashes",
+			namespace:  "My/Namespace",
+			name:       "My/Name",
+			expURLPath: "/api/v1/rules/My%2FNamespace/My%2FName",
+		},
+	} {
+		t.Run(tc.test, func(t *testing.T) {
+			ctx := context.Background()
+			require.NoError(t, client.DeleteRuleGroup(ctx, tc.namespace, tc.name))
+
+			req := <-requestCh
+			require.Equal(t, tc.expURLPath, req.URL.EscapedPath())
+
+		})
+	}
+
+}


### PR DESCRIPTION
fix: Ensure special characters in rule and namespace names are handled correctly


Signed-off-by: Christian Simon <simon@swine.de>