### PR TITLE
feat: Incorporate promtool duplicate rules check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 ## Unreleased
 
 * [ENHANCEMENT] Return detailed HTTP error messages. #146
+* [ENHANCEMENT] Check for duplicate rule records in `cortextool rules check`. #149
 
 ## v0.7.2
 

--- a/pkg/commands/rules_test.go
+++ b/pkg/commands/rules_test.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCheckDuplicates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []rwrulefmt.RuleGroup
+		want []compareRuleType
+	}{
+		{
+			name: "no duplicates",
+			in: []rwrulefmt.RuleGroup{{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "rulegroup",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record: yaml.Node{Value: "up"},
+							Expr:   yaml.Node{Value: "up==1"},
+						},
+						{
+							Record: yaml.Node{Value: "down"},
+							Expr:   yaml.Node{Value: "up==0"},
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{},
+			}},
+			want: nil,
+		},
+		{
+			name: "with duplicates",
+			in: []rwrulefmt.RuleGroup{{
+				RuleGroup: rulefmt.RuleGroup{
+					Name: "rulegroup",
+					Rules: []rulefmt.RuleNode{
+						{
+							Record: yaml.Node{Value: "up"},
+							Expr:   yaml.Node{Value: "up==1"},
+						},
+						{
+							Record: yaml.Node{Value: "up"},
+							Expr:   yaml.Node{Value: "up==0"},
+						},
+					},
+				},
+				RWConfigs: []rwrulefmt.RemoteWriteConfig{},
+			}},
+			want: []compareRuleType{{metric: "up", label: map[string]string(nil)}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, checkDuplicates(tc.in))
+		})
+	}
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -74,7 +74,7 @@ func (r RuleNamespace) LintExpressions(backend string) (int, int, error) {
 
 // CheckRecordingRules checks that recording rules have at least one colon in their name, this is based
 // on the recording rules best practices here: https://prometheus.io/docs/practices/rules/
-// Returns the number of rules that don't match the requirements, and error if that number is not 0.
+// Returns the number of rules that don't match the requirements.
 func (r RuleNamespace) CheckRecordingRules(strict bool) int {
 	var name string
 	var count int


### PR DESCRIPTION
Resolves #148.

Removes the need for users to sanitize Cortex rules files in order to us `promtool check rules`.

Tested with:

```console
$ cat <<EOF > rules.yml
namespace: test
groups:
    - name: test
      rules:
        - expr: up == 1
          record: up:rule
        - expr: up == 0
          record: up:rule
EOF
$ ./cmd/cortextool/cortextool rules check rules.yml 
1 duplicate rule(s) found.
Metric: up:rule
Label(s):
Might cause inconsistency while recording expressions.
```