### PR TITLE
feat: more granular loadgen histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,6 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## Unreleased
 
-var writeRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "loadgen",
-	Name:      "write_request_duration_seconds",
-	Buckets:   defBuckets,
-}, []string{"success"})
-
-var queryRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Namespace: "loadgen",
-	Name:      "query_request_duration_seconds",
-	Buckets:   defBuckets,
-}, []string{"success"})
-
 * [CHANGE] Loadgen: Add `loadgen` namespace to loadgen metrics. #152
   * `write_request_duration_seconds` --> `loadgen_write_request_duration_seconds`
   * `query_request_duration_seconds` --> `loadgen_query_request_duration_seconds`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,24 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## Unreleased
 
+var writeRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "loadgen",
+	Name:      "write_request_duration_seconds",
+	Buckets:   defBuckets,
+}, []string{"success"})
+
+var queryRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "loadgen",
+	Name:      "query_request_duration_seconds",
+	Buckets:   defBuckets,
+}, []string{"success"})
+
+* [CHANGE] Loadgen: Add `loadgen` namespace to loadgen metrics. #152
+  * `write_request_duration_seconds` --> `loadgen_write_request_duration_seconds`
+  * `query_request_duration_seconds` --> `loadgen_query_request_duration_seconds`
 * [ENHANCEMENT] Return detailed HTTP error messages. #146
 * [ENHANCEMENT] Check for duplicate rule records in `cortextool rules check`. #149
+* [ENHANCEMENT] Loadgen: Metrics now use histogram with an additional `15` bucket.
 
 ## v0.7.2
 

--- a/pkg/commands/loadgen.go
+++ b/pkg/commands/loadgen.go
@@ -26,14 +26,22 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
+var (
+	// 15 seconds is a common send interval. To provide useful metrics at high latencies we will
+	// add 15 to the default Prometheus buckets
+	defBuckets = append(prometheus.DefBuckets, 15)
+)
+
 var writeRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "write_request_duration_seconds",
-	Buckets: prometheus.DefBuckets,
+	Namespace: "loadgen",
+	Name:      "write_request_duration_seconds",
+	Buckets:   defBuckets,
 }, []string{"success"})
 
 var queryRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-	Name:    "query_request_duration_seconds",
-	Buckets: prometheus.DefBuckets,
+	Namespace: "loadgen",
+	Name:      "query_request_duration_seconds",
+	Buckets:   defBuckets,
 }, []string{"success"})
 
 type LoadgenCommand struct {


### PR DESCRIPTION
- Add 15 seconds as a bucket interval for loadgen metrics
- Add `loadgen` as namespace for loadgen metrics
