### PR TITLE
fix: Rule namespaces and groups containing slashes

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path"
+	"strings"
 	"time"
 
 	"github.com/cortexproject/cortex/pkg/util/tls"
@@ -174,6 +174,12 @@ func checkResponse(r *http.Response) error {
 	return errors.New(errMsg)
 }
 
+func joinPath(baseURLPath, targetPath string) string {
+	// trim exactly one slash at the end of the base URL, this expects target
+	// path to always start with a slash
+	return strings.TrimSuffix(baseURLPath, "/") + targetPath
+}
+
 func buildRequest(p, m string, endpoint url.URL, payload []byte) (*http.Request, error) {
 	// parse path parameter again (as it already contains escaped path information
 	pURL, err := url.Parse(p)
@@ -183,8 +189,8 @@ func buildRequest(p, m string, endpoint url.URL, payload []byte) (*http.Request,
 
 	// if path or endpoint contains escaping that requires RawPath to be populated, also join rawPath
 	if pURL.RawPath != "" || endpoint.RawPath != "" {
-		endpoint.RawPath = path.Join(endpoint.EscapedPath(), pURL.EscapedPath())
+		endpoint.RawPath = joinPath(endpoint.EscapedPath(), pURL.EscapedPath())
 	}
-	endpoint.Path = path.Join(endpoint.Path, pURL.Path)
+	endpoint.Path = joinPath(endpoint.Path, pURL.Path)
 	return http.NewRequest(m, endpoint.String(), bytes.NewBuffer(payload))
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTrailingSlash(t *testing.T) {
+func TestBuildURL(t *testing.T) {
 	tc := []struct {
 		name      string
 		path      string
@@ -36,6 +36,48 @@ func TestTrailingSlash(t *testing.T) {
 			method:    http.MethodPost,
 			url:       "http://cortexurl.com/apathto",
 			resultURL: "http://cortexurl.com/apathto/api/v1/rules",
+		},
+		{
+			name:      "builds the correct URL when the base url has a path with trailing slash",
+			path:      "/api/v1/rules",
+			method:    http.MethodPost,
+			url:       "http://cortexurl.com/apathto/",
+			resultURL: "http://cortexurl.com/apathto/api/v1/rules",
+		},
+		{
+			name:      "builds the correct URL with a trailing slash and the target path contains special characters",
+			path:      "/api/v1/rules/%20%2Fspace%F0%9F%8D%BB",
+			method:    http.MethodPost,
+			url:       "http://cortexurl.com/",
+			resultURL: "http://cortexurl.com/api/v1/rules/%20%2Fspace%F0%9F%8D%BB",
+		},
+		{
+			name:      "builds the correct URL without a trailing slash and the target path contains special characters",
+			path:      "/api/v1/rules/%20%2Fspace%F0%9F%8D%BB",
+			method:    http.MethodPost,
+			url:       "http://cortexurl.com",
+			resultURL: "http://cortexurl.com/api/v1/rules/%20%2Fspace%F0%9F%8D%BB",
+		},
+		{
+			name:      "builds the correct URL when the base url has a path and the target path contains special characters",
+			path:      "/api/v1/rules/%20%2Fspace%F0%9F%8D%BB",
+			method:    http.MethodPost,
+			url:       "http://cortexurl.com/apathto",
+			resultURL: "http://cortexurl.com/apathto/api/v1/rules/%20%2Fspace%F0%9F%8D%BB",
+		},
+		{
+			name:      "builds the correct URL when the base url has a path and the target path starts with a escaped slash",
+			path:      "/api/v1/rules/%2F-first-char-slash",
+			method:    http.MethodPost,
+			url:       "http://cortexurl.com/apathto",
+			resultURL: "http://cortexurl.com/apathto/api/v1/rules/%2F-first-char-slash",
+		},
+		{
+			name:      "builds the correct URL when the base url has a path and the target path ends with a escaped slash",
+			path:      "/api/v1/rules/last-char-slash%2F",
+			method:    http.MethodPost,
+			url:       "http://cortexurl.com/apathto",
+			resultURL: "http://cortexurl.com/apathto/api/v1/rules/last-char-slash%2F",
 		},
 	}
 

--- a/pkg/client/rules_test.go
+++ b/pkg/client/rules_test.go
@@ -50,6 +50,18 @@ func TestCortexClient_X(t *testing.T) {
 			name:       "My/Name",
 			expURLPath: "/api/v1/rules/My%2FNamespace/My%2FName",
 		},
+		{
+			test:       "special-characters-slash-first",
+			namespace:  "My/Namespace",
+			name:       "/first-char-slash",
+			expURLPath: "/api/v1/rules/My%2FNamespace/%2Ffirst-char-slash",
+		},
+		{
+			test:       "special-characters-slash-first",
+			namespace:  "My/Namespace",
+			name:       "last-char-slash/",
+			expURLPath: "/api/v1/rules/My%2FNamespace/last-char-slash%2F",
+		},
 	} {
 		t.Run(tc.test, func(t *testing.T) {
 			ctx := context.Background()


### PR DESCRIPTION
This fixes the escaping for slashes as first and last character in the rule namespace or group name. The use of path.Join was not ideal as it trimmed too many slashes.

Signed-off-by: Christian Simon <simon@swine.de>