### PR TITLE
Add --label-excluded-rule-groups to cortextool rules prepare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## unreleased/master
 
-* [FEATURE] Add `--label-excluded-rule-groups` support to `cortextool rules prepare` command. #160
+* [FEATURE] Add `--label-excluded-rule-groups` support to `cortextool rules prepare` command. #174
 * [ENHANCEMENT] Upgrade the Go version used in build images and tests to golang 1.16.3 to match upstream Cortex. #165
 
 ## v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## unreleased/master
 
+* [FEATURE] Add `--label-excluded-rule-groups` support to `cortextool rules prepare` command. #160
 * [ENHANCEMENT] Upgrade the Go version used in build images and tests to golang 1.16.3 to match upstream Cortex. #165
 
 ## v0.9.0

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -204,7 +204,7 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 		"edits the rule file in place",
 	).Short('i').BoolVar(&r.InPlaceEdit)
 	prepareCmd.Flag("label", "label to include as part of the aggregations.").Default(defaultPrepareAggregationLabel).Short('l').StringVar(&r.AggregationLabel)
-	prepareCmd.Flag("label-excluded-rule-groups", "Comma separated list of rule group names to exclude when injecting the configured label to aggregations.").StringVar(&r.AggregationLabelExcludedRuleGroups)
+	prepareCmd.Flag("label-excluded-rule-groups", "Comma separated list of rule group names to exclude when including the configured label to aggregations.").StringVar(&r.AggregationLabelExcludedRuleGroups)
 
 	// Lint Command
 	lintCmd.Arg("rule-files", "The rule files to check.").ExistingFilesVar(&r.RuleFilesList)


### PR DESCRIPTION
We have an use case where we need to not apply the label aggregation to specific rule groups. To satify this use case, in this PR I'm proposing to add `--label-excluded-rule-groups` support to `cortextool rules prepare` command.