### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,9 +70,7 @@ changelog:
 dockers:
   - goos: linux
     goarch: amd64
-    binaries:
-      - cortextool
-    builds:
+    ids:
       - cortextool-linux
     dockerfile: cmd/cortextool/GR.Dockerfile
     image_templates:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ $ git tag -s "${tag}" -m "${tag}"
 $ git push origin "${tag}"
 ```
 
-3. Run `$ goreleaser --release-notes=changelogs/v0.3.0.md --rm-dist` where the changelog file is the one created as part of step 1.
+3. Run `$ goreleaser release --release-notes=changelogs/v0.3.0.md --rm-dist` where the changelog file is the one created as part of step 1.
 4. The docker image will be pushed automatically.
 
 


### PR DESCRIPTION
I've just released `v0.10.0` and, while preparing it, I've noticed the goreleaser config and doc is based on a older version of goreleaser which doesn't work with the latest. This PR fixes it to make it work with the latest release.