### PR TITLE
Allow parsing rules from a byte slice.

### DIFF
--- a/pkg/rules/parser.go
+++ b/pkg/rules/parser.go
@@ -77,6 +77,10 @@ func Parse(f string) ([]RuleNamespace, []error) {
 		return nil, []error{errFileReadError}
 	}
 
+	return ParseBytes(content)
+}
+
+func ParseBytes(content []byte) ([]RuleNamespace, []error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(content))
 	decoder.KnownFields(true)
 


### PR DESCRIPTION
The rule parser currently allows reading rules from file(s). Parsing a
byte slice (which was removed as part of grafana/cortex-tools#80) might
still be useful to some users.