### PR TITLE
add the ability to specify the basic auth user

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,7 @@ var (
 
 // Config is used to configure a Ruler Client
 type Config struct {
+	User            string `yaml:"user"`
 	Key             string `yaml:"key"`
 	Address         string `yaml:"address"`
 	ID              string `yaml:"id"`
@@ -37,6 +38,7 @@ type Config struct {
 
 // CortexClient is used to get and load rules into a cortex ruler
 type CortexClient struct {
+	user     string
 	key      string
 	id       string
 	endpoint *url.URL
@@ -80,6 +82,7 @@ func New(cfg Config) (*CortexClient, error) {
 	}
 
 	return &CortexClient{
+		user:     cfg.User,
 		key:      cfg.Key,
 		id:       cfg.ID,
 		endpoint: endpoint,
@@ -108,7 +111,9 @@ func (r *CortexClient) doRequest(path, method string, payload []byte) (*http.Res
 		return nil, err
 	}
 
-	if r.key != "" {
+	if r.user != "" {
+		req.SetBasicAuth(r.user, r.key)
+	} else if r.key != "" {
 		req.SetBasicAuth(r.id, r.key)
 	}
 

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -87,6 +87,7 @@ type RuleCommand struct {
 // Register rule related commands and flags with the kingpin application
 func (r *RuleCommand) Register(app *kingpin.Application) {
 	rulesCmd := app.Command("rules", "View & edit rules stored in cortex.").PreAction(r.setup)
+	rulesCmd.Flag("user", "Api user to use when contacting cortex, alternatively set $CORTEX_API_USER.").Default("").Envar("CORTEX_API_USER").StringVar(&r.ClientConfig.User)
 	rulesCmd.Flag("key", "Api key to use when contacting cortex, alternatively set $CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&r.ClientConfig.Key)
 	rulesCmd.Flag("backend", "Backend type to interact with: <cortex|loki>").Default("cortex").EnumVar(&r.Backend, backends...)
 


### PR DESCRIPTION
This PR allows to specify the basic auth user explicitly instead of assume the id is the username for authentication.

This fixes #186.