### PR TITLE
benchtool: avoid registering DNS metrics twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## unreleased/master
 
+* [BUGFIX] Benchtool: avoid duplicate DNS metrics registration. #188
 * [ENHANCEMENT] Added the ability to set an explicit user when Cortex is behind basic auth. #187
 
 ## v0.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## unreleased/master
 
-* [BUGFIX] Benchtool: avoid duplicate DNS metrics registration. #188
+* [BUGFIX] Benchtool: avoid duplicate DNS metrics registration when enabling both query and write benchmarking. #188
 * [ENHANCEMENT] Added the ability to set an explicit user when Cortex is behind basic auth. #187
 
 ## v0.10.1

--- a/pkg/bench/query_runner.go
+++ b/pkg/bench/query_runner.go
@@ -64,7 +64,7 @@ func newQueryRunner(id string, tenantName string, cfg QueryConfig, workload *que
 		clientPool: map[string]v1.API{},
 		dnsProvider: dns.NewProvider(
 			logger,
-			extprom.WrapRegistererWithPrefix("benchtool_", reg),
+			extprom.WrapRegistererWithPrefix("benchtool_query_", reg),
 			dns.GolangResolverType,
 		),
 

--- a/pkg/bench/write_runner.go
+++ b/pkg/bench/write_runner.go
@@ -67,7 +67,7 @@ func NewWriteBenchmarkRunner(id string, tenantName string, cfg WriteBenchConfig,
 		workload: workload,
 		dnsProvider: dns.NewProvider(
 			logger,
-			extprom.WrapRegistererWithPrefix("benchtool_", reg),
+			extprom.WrapRegistererWithPrefix("benchtool_write_", reg),
 			dns.GolangResolverType,
 		),
 		clientPool: map[string]*writeClient{},


### PR DESCRIPTION
Enabling both query and write capabilities (`bench.query.enabled`, `bench.write.enabled`) will result in this error on startup:
```
panic: duplicate metrics collector registration attempted
```

Use a different metric prefix for query and write runners.