### PR TITLE
Add Arm64 on Darwin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
   - id: cortextool-linux
     ldflags:
       -s -w -X github.com/grafana/cortex-tools/pkg/version.Version={{.Version}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
-## unreleased/master
+## v0.10.2
 
 * [FEATURE] Blockgen: adding a new tool to generate blocks of mock data.
-* [BUGFIX] Benchtool: avoid duplicate DNS metrics registration when enabling both query and write benchmarking. #188
+* [FEATURE] Support Arm64 on Darwin.
 * [ENHANCEMENT] Added the ability to set an explicit user when Cortex is behind basic auth. #187
+* [BUGFIX] Benchtool: avoid duplicate DNS metrics registration when enabling both query and write benchmarking. #188
 
 ## v0.10.1
 

--- a/changelogs/v0.10.2.md
+++ b/changelogs/v0.10.2.md
@@ -1,0 +1,23 @@
+# v0.10.2 Release
+
+## Changes
+
+* [FEATURE] Blockgen: adding a new tool to generate blocks of mock data.
+* [FEATURE] Support Arm64 on Darwin.
+* [ENHANCEMENT] Added the ability to set an explicit user when Cortex is behind basic auth. #187
+* [BUGFIX] Benchtool: avoid duplicate DNS metrics registration when enabling both query and write benchmarking. #188
+
+## Installation
+
+## cortextool
+
+```console
+# download the binary (adapt os and arch as needed)
+$ curl -fSL -o "/usr/local/bin/cortextool" "https://github.com/grafana/cortex-tools/releases/download/v0.10.1/cortextool_0.10.1_linux_x86_64"
+
+# make it executable
+$ chmod a+x "/usr/local/bin/cortextool"
+
+# have fun :)
+$ cortextool --help
+```


### PR DESCRIPTION
I've only done step 1 of Release Process: GoReleaser:
https://github.com/grafana/cortex-tools/blame/main/RELEASE.md#L6

For a couple of reasons:
1. I didn't want to create and push a new tag until this is approved & merged
2. I'm on an Arm64 Darwin machine myself, and so far I've found that when I try to build a Linux Amd64 Docker image, it never runs successfully on our linux machines on GCP - so I'm hoping someone on a linux machine (or an Amd64 Mac) can do step 3 for me (running `goreleaser release`).

I haven't tested the code change in this PR yet - I'm not sure how to exactly. I was looking in the Makefile for something I could run, but didn't spot anything yet. Cheers!