### PR TITLE
Add analyse ruler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 /cortextool
 /metrics-in-grafana.json
 /prometheus-metrics.json
+/metrics-in-ruler.json

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ cortextool analyse ruler --address=https://prometheus-blocks-prod-us-central1.gr
 
 ##### `analyse prometheus`
 
-This command will run against your Prometheus / Cloud Prometheus instance. It will then use the output from `grafana-analyse` to show you how many series in the Prometheus server are actually being used in dashboards and rules. Also, it'll show which metrics exist in Grafana Cloud that are **not** in dashboards or rules. The output is a JSON file
+This command will run against your Prometheus / Cloud Prometheus instance. It will then use the output from `analyse grafana` and `analyse ruler` to show you how many series in the Prometheus server are actually being used in dashboards and rules. Also, it'll show which metrics exist in Grafana Cloud that are **not** in dashboards or rules. The output is a JSON file.
 
 ###### Configuration
 
@@ -251,7 +251,7 @@ This command will run against your Prometheus / Cloud Prometheus instance. It wi
 ###### Running the command
 
 ```shell
-cortextool analyse prometheus --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --password=<API-Key> --log.level=debug
+cortextool analyse prometheus --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --key=<API-Key> --log.level=debug
 ```
 
 ##### `analyse dashboard`

--- a/README.md
+++ b/README.md
@@ -193,11 +193,12 @@ This lets you generate the header which can then be used to enforce access contr
 
 #### Analyse
 
-Run analysis against your Prometheus, Grafana and Cortex to see which metrics being used and exported.
+Run analysis against your Prometheus, Grafana and Cortex to see which metrics being used and exported. Can also extract metrics
+from dashboard JSON and rules YAML files.
 
-##### grafana-analyse 
+##### `analyse grafana`
 
-This command will be run against your Grafana instance and it will download the dashboards and pick the Prometheus metrics that are used in the queries. The output is a JSON file.
+This command will run against your Grafana instance and will download its dashboards and then extract the Prometheus metrics used in its queries. The output is a JSON file.
 
 ###### Configuration
 
@@ -213,24 +214,66 @@ This command will be run against your Grafana instance and it will download the 
 cortextool analyse grafana --address=<grafana-address> --key=<API-Key>
 ```
 
-##### prometheus-analyse 
+##### `analyse ruler`
 
-This command will be run against your Prometheus / GrafanaCloud instance, then it will use the output from `grafana-analyse` show you how many series in the Prometheus server are actually being used in dashboards. Also, it'll show which metrics exist in Grafana Cloud that are **not** in dashboards. The output is a JSON file
+This command will run against your Grafana Cloud Prometheus instance and will fetch its rule groups. It will then extract the Prometheus metrics used in the rule queries. The output is a JSON file.
 
 ###### Configuration
 
 | Env Variables     | Flag      | Description                                                                                                   |
 | ----------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
 | CORTEX_ADDRESS    | `address` | Address of the Prometheus  instance.                                                              |
-| CORTEX_TENANT_ID  | `id`   |  If you're using GrafanaCloud this is your instance ID. |
-|  CORTEX_API_KEY   | `key`   |  If you're using GrafanaCloud this is your API Key. |
+| CORTEX_TENANT_ID  | `id`   |  If you're using Grafana Cloud this is your instance ID. |
+|  CORTEX_API_KEY   | `key`   |  If you're using Grafana Cloud this is your API Key. |
 | __ | `grafana-metrics-file`      | The input file path. metrics-in-grafana.json by default.  |
-| __ | `output`      | The output file path. prometheus-metrics.json by default.  |
+| __ | `ruler-metrics-file`      | The input file path. metrics-in-ruler.json by default.  |
+| __ | `output`      | The output file path. metrics-in-ruler.json by default.  |
 
 ###### Running the command
 
 ```
-cortextool analyse prometheus --address=https://prometheus-us-central1.grafana.net/api/prom --username=<1234> --password=<API-Key> --log.level=debug
+cortextool analyse ruler --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --key=<API-Key>
+```
+
+##### `analyse prometheus`
+
+This command will run against your Prometheus / Cloud Prometheus instance. It will then use the output from `grafana-analyse` to show you how many series in the Prometheus server are actually being used in dashboards and rules. Also, it'll show which metrics exist in Grafana Cloud that are **not** in dashboards or rules. The output is a JSON file
+
+###### Configuration
+
+| Env Variables     | Flag      | Description                                                                                                   |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
+| CORTEX_ADDRESS    | `address` | Address of the Prometheus  instance.                                                              |
+| CORTEX_TENANT_ID  | `id`   |  If you're using Grafana Cloud this is your instance ID. |
+|  CORTEX_API_KEY   | `key`   |  If you're using Grafana Cloud this is your API Key. |
+| __ | `grafana-metrics-file`      | The dashboard metrics input file path. `metrics-in-grafana.json` by default.  |
+| __ | `ruler-metrics-file`      | The rules metrics input file path. `metrics-in-ruler.json` by default.  |
+| __ | `output`      | The output file path. `prometheus-metrics.json` by default.  |
+
+###### Running the command
+
+```
+cortextool analyse prometheus --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --password=<API-Key> --log.level=debug
+```
+
+##### `analyse dashboard`
+
+This command accepts Grafana dashboard JSON files as input and extracts Prometheus metrics used in the queries. The output is a JSON file compatible with `analyse prometheus`.
+
+###### Running the command
+
+```
+cortextool analyse dashboard ./dashboard_one.json ./dashboard_two.json ...
+```
+
+##### `analyse rule-file`
+
+This command accepts Prometheus rule YAML files as input and extracts Prometheus metrics used in the queries. The output is a JSON file compatible with `analyse prometheus`.
+
+###### Running the command
+
+```
+cortextool analyse rule-file ./rule_file_one.yaml ./rule_file_two.yaml ...
 ```
 
 ## chunktool

--- a/README.md
+++ b/README.md
@@ -214,6 +214,35 @@ This command will run against your Grafana instance and will download its dashbo
 cortextool analyse grafana --address=<grafana-address> --key=<API-Key>
 ```
 
+###### Sample output
+
+```json
+{
+  "metricsUsed": [
+    "apiserver_request:availability30d",
+    "workqueue_depth",
+    "workqueue_queue_duration_seconds_bucket", 
+    . . .
+  ],
+  "dashboards": [
+    {
+      "slug": "",
+      "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
+      "title": "Kubernetes / API server",
+      "metrics": [
+        "apiserver_request:availability30d",
+        "apiserver_request_total",
+        "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
+        "workqueue_depth",
+        "workqueue_queue_duration_seconds_bucket",
+        . . .
+      ],
+      "parse_errors": null
+    }
+  ]
+}
+```
+
 ##### `analyse ruler`
 
 This command will run against your Grafana Cloud Prometheus instance and will fetch its rule groups. It will then extract the Prometheus metrics used in the rule queries. The output is a JSON file.
@@ -231,6 +260,31 @@ This command will run against your Grafana Cloud Prometheus instance and will fe
 
 ```shell
 cortextool analyse ruler --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --key=<API-Key>
+```
+
+###### Sample output
+
+```json
+{
+  "metricsUsed": [
+    "apiserver_request_duration_seconds_bucket",
+    "container_cpu_usage_seconds_total",
+    "scheduler_scheduling_algorithm_duration_seconds_bucket"
+    . . .
+  ],
+  "ruleGroups": [
+    {
+      "namspace": "prometheus_rules",
+      "name": "kube-apiserver.rules",
+      "metrics": [
+        "apiserver_request_duration_seconds_bucket",
+        "apiserver_request_duration_seconds_count",
+        "apiserver_request_total"
+      ],
+      "parse_errors": null
+    },
+    . . .
+}
 ```
 
 ##### `analyse prometheus`
@@ -252,6 +306,50 @@ This command will run against your Prometheus / Cloud Prometheus instance. It wi
 
 ```shell
 cortextool analyse prometheus --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --key=<API-Key> --log.level=debug
+```
+
+###### Sample output
+
+```json
+{
+  "total_active_series": 38184,
+  "in_use_active_series": 14047,
+  "additional_active_series": 24137,
+  "in_use_metric_counts": [
+    {
+      "metric": "apiserver_request_duration_seconds_bucket",
+      "count": 11400,
+      "job_counts": [
+        {
+          "job": "apiserver",
+          "count": 11400
+        }
+      ]
+    },
+    {
+      "metric": "apiserver_request_total",
+      "count": 684,
+      "job_counts": [
+        {
+          "job": "apiserver",
+          "count": 684
+        }
+      ]
+    },
+    . . .
+  ],
+  "additional_metric_counts": [
+    {
+      "metric": "etcd_request_duration_seconds_bucket",
+      "count": 2688,
+      "job_counts": [
+        {
+          "job": "apiserver",
+          "count": 2688
+        }
+      ]
+    },
+    . . .
 ```
 
 ##### `analyse dashboard`

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ cortextool analyse grafana --address=<grafana-address> --key=<API-Key>
     "apiserver_request:availability30d",
     "workqueue_depth",
     "workqueue_queue_duration_seconds_bucket", 
-    . . .
+    ...
   ],
   "dashboards": [
     {
@@ -235,7 +235,7 @@ cortextool analyse grafana --address=<grafana-address> --key=<API-Key>
         "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
         "workqueue_depth",
         "workqueue_queue_duration_seconds_bucket",
-        . . .
+        ...
       ],
       "parse_errors": null
     }
@@ -270,7 +270,7 @@ cortextool analyse ruler --address=https://prometheus-blocks-prod-us-central1.gr
     "apiserver_request_duration_seconds_bucket",
     "container_cpu_usage_seconds_total",
     "scheduler_scheduling_algorithm_duration_seconds_bucket"
-    . . .
+    ...
   ],
   "ruleGroups": [
     {
@@ -283,7 +283,7 @@ cortextool analyse ruler --address=https://prometheus-blocks-prod-us-central1.gr
       ],
       "parse_errors": null
     },
-    . . .
+    ...
 }
 ```
 
@@ -336,7 +336,7 @@ cortextool analyse prometheus --address=https://prometheus-blocks-prod-us-centra
         }
       ]
     },
-    . . .
+    ...
   ],
   "additional_metric_counts": [
     {
@@ -349,7 +349,7 @@ cortextool analyse prometheus --address=https://prometheus-blocks-prod-us-centra
         }
       ]
     },
-    . . .
+    ...
 ```
 
 ##### `analyse dashboard`

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ This command will run against your Grafana instance and will download its dashbo
 
 ###### Running the command
 
-```
+```shell
 cortextool analyse grafana --address=<grafana-address> --key=<API-Key>
 ```
 
@@ -225,13 +225,11 @@ This command will run against your Grafana Cloud Prometheus instance and will fe
 | CORTEX_ADDRESS    | `address` | Address of the Prometheus  instance.                                                              |
 | CORTEX_TENANT_ID  | `id`   |  If you're using Grafana Cloud this is your instance ID. |
 |  CORTEX_API_KEY   | `key`   |  If you're using Grafana Cloud this is your API Key. |
-| __ | `grafana-metrics-file`      | The input file path. metrics-in-grafana.json by default.  |
-| __ | `ruler-metrics-file`      | The input file path. metrics-in-ruler.json by default.  |
 | __ | `output`      | The output file path. metrics-in-ruler.json by default.  |
 
 ###### Running the command
 
-```
+```shell
 cortextool analyse ruler --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --key=<API-Key>
 ```
 
@@ -252,7 +250,7 @@ This command will run against your Prometheus / Cloud Prometheus instance. It wi
 
 ###### Running the command
 
-```
+```shell
 cortextool analyse prometheus --address=https://prometheus-blocks-prod-us-central1.grafana.net --id=<1234> --password=<API-Key> --log.level=debug
 ```
 
@@ -262,7 +260,7 @@ This command accepts Grafana dashboard JSON files as input and extracts Promethe
 
 ###### Running the command
 
-```
+```shell
 cortextool analyse dashboard ./dashboard_one.json ./dashboard_two.json ...
 ```
 
@@ -272,7 +270,7 @@ This command accepts Prometheus rule YAML files as input and extracts Prometheus
 
 ###### Running the command
 
-```
+```shell
 cortextool analyse rule-file ./rule_file_one.yaml ./rule_file_two.yaml ...
 ```
 

--- a/pkg/analyse/grafana.go
+++ b/pkg/analyse/grafana.go
@@ -2,7 +2,7 @@ package analyse
 
 type MetricsInGrafana struct {
 	MetricsUsed    []string            `json:"metricsUsed"`
-	OverallMetrics map[string]struct{} `json:"overallMetrics"`
+	OverallMetrics map[string]struct{} `json:"-"`
 	Dashboards     []DashboardMetrics  `json:"dashboards"`
 }
 

--- a/pkg/analyse/grafana.go
+++ b/pkg/analyse/grafana.go
@@ -1,8 +1,9 @@
 package analyse
 
 type MetricsInGrafana struct {
-	MetricsUsed []string           `json:"metricsUsed"`
-	Dashboards  []DashboardMetrics `json:"dashboards"`
+	MetricsUsed    []string            `json:"metricsUsed"`
+	OverallMetrics map[string]struct{} `json:"overallMetrics"`
+	Dashboards     []DashboardMetrics  `json:"dashboards"`
 }
 
 type DashboardMetrics struct {

--- a/pkg/analyse/ruler.go
+++ b/pkg/analyse/ruler.go
@@ -1,10 +1,8 @@
 package analyse
 
-import "github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
-
 type MetricsInRuler struct {
 	MetricsUsed    []string            `json:"metricsUsed"`
-	OverallMetrics map[string]struct{} `json:"overallMetrics"`
+	OverallMetrics map[string]struct{} `json:"-"`
 	RuleGroups     []RuleGroupMetrics  `json:"ruleGroups"`
 }
 
@@ -13,9 +11,4 @@ type RuleGroupMetrics struct {
 	GroupName   string   `json:"name"`
 	Metrics     []string `json:"metrics"`
 	ParseErrors []string `json:"parse_errors"`
-}
-
-type RuleConfig struct {
-	Namespace  string                `yaml:"namespace"`
-	RuleGroups []rwrulefmt.RuleGroup `yaml:"groups"`
 }

--- a/pkg/analyse/ruler.go
+++ b/pkg/analyse/ruler.go
@@ -1,0 +1,13 @@
+package analyse
+
+type MetricsInRuler struct {
+	MetricsUsed []string           `json:"metricsUsed"`
+	RuleGroups  []RuleGroupMetrics `json:"ruleGroups"`
+}
+
+type RuleGroupMetrics struct {
+	Namespace   string   `json:"namspace"`
+	GroupName   string   `json:"name"`
+	Metrics     []string `json:"metrics"`
+	ParseErrors []string `json:"parse_errors"`
+}

--- a/pkg/analyse/ruler.go
+++ b/pkg/analyse/ruler.go
@@ -1,8 +1,11 @@
 package analyse
 
+import "github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
+
 type MetricsInRuler struct {
-	MetricsUsed []string           `json:"metricsUsed"`
-	RuleGroups  []RuleGroupMetrics `json:"ruleGroups"`
+	MetricsUsed    []string            `json:"metricsUsed"`
+	OverallMetrics map[string]struct{} `json:"overallMetrics"`
+	RuleGroups     []RuleGroupMetrics  `json:"ruleGroups"`
 }
 
 type RuleGroupMetrics struct {
@@ -10,4 +13,9 @@ type RuleGroupMetrics struct {
 	GroupName   string   `json:"name"`
 	Metrics     []string `json:"metrics"`
 	ParseErrors []string `json:"parse_errors"`
+}
+
+type RuleConfig struct {
+	Namespace  string                `yaml:"namespace"`
+	RuleGroups []rwrulefmt.RuleGroup `yaml:"groups"`
 }

--- a/pkg/commands/analyse.go
+++ b/pkg/commands/analyse.go
@@ -56,7 +56,7 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 		StringVar(&gaCmd.outputFile)
 
 	raCmd := &RulerAnalyseCommand{}
-	rulerAnalyseCmd := analyseCmd.Command("ruler", "Analyse and output the metrics used in Cortex rules.").
+	rulerAnalyseCmd := analyseCmd.Command("ruler", "Analyse and extract the metrics used in Cortex rules").
 		Action(raCmd.run)
 	rulerAnalyseCmd.Flag("address", "Address of the Prometheus/Cortex instance, alternatively set $CORTEX_ADDRESS.").
 		Envar("CORTEX_ADDRESS").

--- a/pkg/commands/analyse.go
+++ b/pkg/commands/analyse.go
@@ -32,7 +32,7 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 		StringVar(&paCmd.grafanaMetricsFile)
 	prometheusAnalyseCmd.Flag("ruler-metrics-file", "The path for the input file containing the metrics from ruler-analyse command").
 		Default("metrics-in-ruler.json").
-		StringVar(&paCmd.grafanaMetricsFile)
+		StringVar(&paCmd.rulerMetricsFile)
 	prometheusAnalyseCmd.Flag("output", "The path for the output file").
 		Default("prometheus-metrics.json").
 		StringVar(&paCmd.outputFile)

--- a/pkg/commands/analyse.go
+++ b/pkg/commands/analyse.go
@@ -76,13 +76,19 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 
 	daCmd := &DashboardAnalyseCommand{}
 	dashboardAnalyseCmd := analyseCmd.Command("dashboards", "Analyse and output the metrics used in Grafana dashboard files").Action(daCmd.run)
-	dashboardAnalyseCmd.Flag("files", "Dashboard files").
+	dashboardAnalyseCmd.Arg("files", "Dashboard files").
 		Required().
 		ExistingFilesVar(&daCmd.DashFilesList)
+	dashboardAnalyseCmd.Flag("output", "The path for the output file").
+		Default("metrics-in-grafana.json").
+		StringVar(&daCmd.outputFile)
 
 	rfCmd := &RuleFileAnalyseCommand{}
 	ruleFileAnalyseCmd := analyseCmd.Command("rule-file", "Analyse and output the metrics used in Prometheus rules files").Action(rfCmd.run)
-	ruleFileAnalyseCmd.Flag("files", "Rules files").
+	ruleFileAnalyseCmd.Arg("files", "Rules files").
 		Required().
 		ExistingFilesVar(&rfCmd.RuleFilesList)
+	ruleFileAnalyseCmd.Flag("output", "The path for the output file").
+		Default("metrics-in-ruler.json").
+		StringVar(&rfCmd.outputFile)
 }

--- a/pkg/commands/analyse.go
+++ b/pkg/commands/analyse.go
@@ -30,6 +30,9 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 	prometheusAnalyseCmd.Flag("grafana-metrics-file", "The path for the input file containing the metrics from grafana-analyse command").
 		Default("metrics-in-grafana.json").
 		StringVar(&paCmd.grafanaMetricsFile)
+	prometheusAnalyseCmd.Flag("ruler-metrics-file", "The path for the input file containing the metrics from ruler-analyse command").
+		Default("metrics-in-ruler.json").
+		StringVar(&paCmd.grafanaMetricsFile)
 	prometheusAnalyseCmd.Flag("output", "The path for the output file").
 		Default("prometheus-metrics.json").
 		StringVar(&paCmd.outputFile)
@@ -70,4 +73,16 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 	rulerAnalyseCmd.Flag("output", "The path for the output file").
 		Default("metrics-in-ruler.json").
 		StringVar(&raCmd.outputFile)
+
+	daCmd := &DashboardAnalyseCommand{}
+	dashboardAnalyseCmd := analyseCmd.Command("dashboards", "Analyse and output the metrics used in Grafana dashboard files").Action(daCmd.run)
+	dashboardAnalyseCmd.Flag("files", "Dashboard files").
+		Required().
+		ExistingFilesVar(&daCmd.DashFilesList)
+
+	rfCmd := &RuleFileAnalyseCommand{}
+	ruleFileAnalyseCmd := analyseCmd.Command("rule-file", "Analyse and output the metrics used in Prometheus rules files").Action(rfCmd.run)
+	ruleFileAnalyseCmd.Flag("files", "Rules files").
+		Required().
+		ExistingFilesVar(&rfCmd.RuleFilesList)
 }

--- a/pkg/commands/analyse.go
+++ b/pkg/commands/analyse.go
@@ -75,7 +75,7 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 		StringVar(&raCmd.outputFile)
 
 	daCmd := &DashboardAnalyseCommand{}
-	dashboardAnalyseCmd := analyseCmd.Command("dashboards", "Analyse and output the metrics used in Grafana dashboard files").Action(daCmd.run)
+	dashboardAnalyseCmd := analyseCmd.Command("dashboard", "Analyse and output the metrics used in Grafana dashboard files").Action(daCmd.run)
 	dashboardAnalyseCmd.Arg("files", "Dashboard files").
 		Required().
 		ExistingFilesVar(&daCmd.DashFilesList)

--- a/pkg/commands/analyse.go
+++ b/pkg/commands/analyse.go
@@ -51,4 +51,23 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 	grafanaAnalyseCmd.Flag("output", "The path for the output file").
 		Default("metrics-in-grafana.json").
 		StringVar(&gaCmd.outputFile)
+
+	raCmd := &RulerAnalyseCommand{}
+	rulerAnalyseCmd := analyseCmd.Command("ruler", "Analyse and output the metrics used in Cortex rules.").
+		Action(raCmd.run)
+	rulerAnalyseCmd.Flag("address", "Address of the Prometheus/Cortex instance, alternatively set $CORTEX_ADDRESS.").
+		Envar("CORTEX_ADDRESS").
+		Required().
+		StringVar(&raCmd.ClientConfig.Address)
+	rulerAnalyseCmd.Flag("id", "Username to use when contacting Prometheus/Cortex, alternatively set $CORTEX_TENANT_ID.").
+		Envar("CORTEX_TENANT_ID").
+		Default("").
+		StringVar(&raCmd.ClientConfig.ID)
+	rulerAnalyseCmd.Flag("key", "Password to use when contacting Prometheus/Cortex, alternatively set $CORTEX_API_KEY.").
+		Envar("CORTEX_API_KEY").
+		Default("").
+		StringVar(&raCmd.ClientConfig.Key)
+	rulerAnalyseCmd.Flag("output", "The path for the output file").
+		Default("metrics-in-ruler.json").
+		StringVar(&raCmd.outputFile)
 }

--- a/pkg/commands/analyse_dashboards.go
+++ b/pkg/commands/analyse_dashboards.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/grafana-tools/sdk"
@@ -16,6 +17,7 @@ type DashboardAnalyseCommand struct {
 
 func (cmd *DashboardAnalyseCommand) run(k *kingpin.ParseContext) error {
 	output := &analyse.MetricsInGrafana{}
+	output.OverallMetrics = make(map[string]struct{})
 
 	for _, file := range cmd.DashFilesList {
 		var board sdk.Board
@@ -24,7 +26,8 @@ func (cmd *DashboardAnalyseCommand) run(k *kingpin.ParseContext) error {
 			return err
 		}
 		if err = json.Unmarshal(buf, &board); err != nil {
-			return (err)
+			fmt.Fprintf(os.Stderr, "%s for %s\n", err, file)
+			continue
 		}
 		parseMetricsInBoard(output, board)
 	}

--- a/pkg/commands/analyse_dashboards.go
+++ b/pkg/commands/analyse_dashboards.go
@@ -1,0 +1,60 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/grafana-tools/sdk"
+	"github.com/grafana/cortex-tools/pkg/analyse"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type DashboardAnalyseCommand struct {
+	DashFilesList []string
+	outputFile    string
+}
+
+func (cmd *DashboardAnalyseCommand) run(k *kingpin.ParseContext) error {
+	output := &analyse.MetricsInGrafana{}
+
+	for _, file := range cmd.DashFilesList {
+		var board sdk.Board
+		buf, err := loadFile(file)
+		if err != nil {
+			return err
+		}
+		if err = json.Unmarshal(buf, &board); err != nil {
+			return (err)
+		}
+		parseMetricsInBoard(output, board)
+	}
+
+	err := writeOut(output, cmd.outputFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func loadFile(filename string) ([]byte, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	fileinfo, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	filesize := fileinfo.Size()
+	buffer := make([]byte, filesize)
+
+	_, err = file.Read(buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer, nil
+}

--- a/pkg/commands/analyse_dashboards.go
+++ b/pkg/commands/analyse_dashboards.go
@@ -6,8 +6,9 @@ import (
 	"os"
 
 	"github.com/grafana-tools/sdk"
-	"github.com/grafana/cortex-tools/pkg/analyse"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
 )
 
 type DashboardAnalyseCommand struct {

--- a/pkg/commands/analyse_grafana.go
+++ b/pkg/commands/analyse_grafana.go
@@ -6,16 +6,18 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/grafana-tools/sdk"
-	"github.com/grafana/cortex-tools/pkg/analyse"
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/promql/parser"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
 )
 
 type GrafanaAnalyseCommand struct {
@@ -27,6 +29,9 @@ type GrafanaAnalyseCommand struct {
 }
 
 func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
+	output := &analyse.MetricsInGrafana{}
+	output.OverallMetrics = make(map[string]struct{})
+
 	ctx, cancel := context.WithTimeout(context.Background(), cmd.readTimeout)
 	defer cancel()
 
@@ -35,9 +40,6 @@ func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
 	if err != nil {
 		return err
 	}
-
-	output := &analyse.MetricsInGrafana{}
-	output.OverallMetrics = make(map[string]struct{})
 
 	for _, link := range boardLinks {
 		board, _, err := c.GetDashboardByUID(ctx, link.UID)
@@ -97,6 +99,9 @@ func parseMetricsInBoard(mig *analyse.MetricsInGrafana, board sdk.Board) {
 		}
 	}
 
+	// Process metrics in templating
+	parseErrors = append(parseErrors, metricsFromTemplating(board.Templating, metrics)...)
+
 	parseErrs := make([]string, 0, len(parseErrors))
 	for _, err := range parseErrors {
 		parseErrs = append(parseErrs, err.Error())
@@ -123,6 +128,39 @@ func parseMetricsInBoard(mig *analyse.MetricsInGrafana, board sdk.Board) {
 
 }
 
+func metricsFromTemplating(templating sdk.Templating, metrics map[string]struct{}) []error {
+	parseErrors := []error{}
+	for _, templateVar := range templating.List {
+		if templateVar.Type != "query" {
+			continue
+		}
+		if query, ok := templateVar.Query.(string); ok {
+			// label_values
+			if strings.Contains(query, "label_values") {
+				re := regexp.MustCompile(`label_values\(([a-zA-Z0-9_]+)`)
+				query = re.FindStringSubmatch(query)[1]
+			}
+			// query_result
+			if strings.Contains(query, "query_result") {
+				re := regexp.MustCompile(`query_result\((.+)\)`)
+				query = re.FindStringSubmatch(query)[1]
+			}
+			err := parseQuery(query, metrics)
+			if err != nil {
+				parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
+				log.Debugln("msg", "promql parse error", "err", err, "query", query)
+				continue
+			}
+		} else {
+			err := fmt.Errorf("templating type error: name=%v", templateVar.Name)
+			parseErrors = append(parseErrors, err)
+			log.Debugln("msg", "templating parse error", "err", err)
+			continue
+		}
+	}
+	return parseErrors
+}
+
 func metricsFromPanel(panel sdk.Panel, metrics map[string]struct{}) []error {
 	parseErrors := []error{}
 	if panel.GetTargets() == nil {
@@ -134,30 +172,38 @@ func metricsFromPanel(panel sdk.Panel, metrics map[string]struct{}) []error {
 		if target.Expr == "" {
 			continue
 		}
-
 		query := target.Expr
-		query = strings.ReplaceAll(query, `$__interval`, "5m")
-		query = strings.ReplaceAll(query, `$interval`, "5m")
-		query = strings.ReplaceAll(query, `$resolution`, "5s")
-		query = strings.ReplaceAll(query, "$__rate_interval", "15s")
-		query = strings.ReplaceAll(query, "$__range", "1d")
-		query = strings.ReplaceAll(query, "${__range_s:glob}", "30")
-		query = strings.ReplaceAll(query, "${__range_s}", "30")
-		expr, err := parser.ParseExpr(query)
+		err := parseQuery(query, metrics)
 		if err != nil {
 			parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
 			log.Debugln("msg", "promql parse error", "err", err, "query", query)
 			continue
 		}
-
-		parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
-			if n, ok := node.(*parser.VectorSelector); ok {
-				metrics[n.Name] = struct{}{}
-			}
-
-			return nil
-		})
 	}
 
 	return parseErrors
+}
+
+func parseQuery(query string, metrics map[string]struct{}) error {
+	query = strings.ReplaceAll(query, `$__interval`, "5m")
+	query = strings.ReplaceAll(query, `$interval`, "5m")
+	query = strings.ReplaceAll(query, `$resolution`, "5s")
+	query = strings.ReplaceAll(query, "$__rate_interval", "15s")
+	query = strings.ReplaceAll(query, "$__range", "1d")
+	query = strings.ReplaceAll(query, "${__range_s:glob}", "30")
+	query = strings.ReplaceAll(query, "${__range_s}", "30")
+	expr, err := parser.ParseExpr(query)
+	if err != nil {
+		return err
+	}
+
+	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+		if n, ok := node.(*parser.VectorSelector); ok {
+			metrics[n.Name] = struct{}{}
+		}
+
+		return nil
+	})
+
+	return nil
 }

--- a/pkg/commands/analyse_grafana.go
+++ b/pkg/commands/analyse_grafana.go
@@ -37,6 +37,7 @@ func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
 	}
 
 	output := &analyse.MetricsInGrafana{}
+	output.OverallMetrics = make(map[string]struct{})
 
 	for _, link := range boardLinks {
 		board, _, err := c.GetDashboardByUID(ctx, link.UID)
@@ -82,6 +83,11 @@ func parseMetricsInBoard(mig *analyse.MetricsInGrafana, board sdk.Board) {
 	// Iterate through all the panels and collect metrics
 	for _, panel := range board.Panels {
 		parseErrors = append(parseErrors, metricsFromPanel(*panel, metrics)...)
+		if panel.RowPanel != nil {
+			for _, subPanel := range panel.RowPanel.Panels {
+				parseErrors = append(parseErrors, metricsFromPanel(subPanel, metrics)...)
+			}
+		}
 	}
 
 	// Iterate through all the rows and collect metrics

--- a/pkg/commands/analyse_grafana.go
+++ b/pkg/commands/analyse_grafana.go
@@ -59,7 +59,7 @@ func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
 }
 
 func writeOut(mig *analyse.MetricsInGrafana, outputFile string) error {
-	metricsUsed := make([]string, 0, len(mig.OverallMetrics))
+	var metricsUsed []string
 	for metric := range mig.OverallMetrics {
 		metricsUsed = append(metricsUsed, metric)
 	}
@@ -79,8 +79,8 @@ func writeOut(mig *analyse.MetricsInGrafana, outputFile string) error {
 }
 
 func parseMetricsInBoard(mig *analyse.MetricsInGrafana, board sdk.Board) {
-	metrics := map[string]struct{}{}
-	parseErrors := make([]error, 0)
+	var parseErrors []error
+	metrics := make(map[string]struct{})
 
 	// Iterate through all the panels and collect metrics
 	for _, panel := range board.Panels {
@@ -102,12 +102,12 @@ func parseMetricsInBoard(mig *analyse.MetricsInGrafana, board sdk.Board) {
 	// Process metrics in templating
 	parseErrors = append(parseErrors, metricsFromTemplating(board.Templating, metrics)...)
 
-	parseErrs := make([]string, 0, len(parseErrors))
+	var parseErrs []string
 	for _, err := range parseErrors {
 		parseErrs = append(parseErrs, err.Error())
 	}
 
-	metricsInBoard := make([]string, 0, len(metrics))
+	var metricsInBoard []string
 	for metric := range metrics {
 		if metric == "" {
 			continue
@@ -162,7 +162,8 @@ func metricsFromTemplating(templating sdk.Templating, metrics map[string]struct{
 }
 
 func metricsFromPanel(panel sdk.Panel, metrics map[string]struct{}) []error {
-	parseErrors := []error{}
+	var parseErrors []error
+
 	if panel.GetTargets() == nil {
 		return parseErrors
 	}

--- a/pkg/commands/analyse_grafana_test.go
+++ b/pkg/commands/analyse_grafana_test.go
@@ -1,0 +1,41 @@
+package commands
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana-tools/sdk"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
+)
+
+func TestParseMetricsInBoard(t *testing.T) {
+	var metrics = []string{
+		"apiserver_request:availability30d",
+		"apiserver_request_total",
+		"cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
+		"code_resource:apiserver_request_total:rate5m",
+		"go_goroutines",
+		"process_cpu_seconds_total",
+		"process_resident_memory_bytes",
+		"workqueue_adds_total",
+		"workqueue_depth",
+		"workqueue_queue_duration_seconds_bucket",
+	}
+
+	var board sdk.Board
+	output := &analyse.MetricsInGrafana{}
+	output.OverallMetrics = make(map[string]struct{})
+
+	buf, err := loadFile("testdata/apiserver.json")
+	if err != nil {
+		t.Errorf("Could not load test dashboard file")
+	}
+	if err = json.Unmarshal(buf, &board); err != nil {
+		t.Errorf("Could not deserialize test dashboard file")
+	}
+
+	parseMetricsInBoard(output, board)
+	assert.Equal(t, metrics, output.Dashboards[0].Metrics)
+}

--- a/pkg/commands/analyse_grafana_test.go
+++ b/pkg/commands/analyse_grafana_test.go
@@ -6,36 +6,35 @@ import (
 
 	"github.com/grafana-tools/sdk"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/cortex-tools/pkg/analyse"
 )
 
-func TestParseMetricsInBoard(t *testing.T) {
-	var metrics = []string{
-		"apiserver_request:availability30d",
-		"apiserver_request_total",
-		"cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
-		"code_resource:apiserver_request_total:rate5m",
-		"go_goroutines",
-		"process_cpu_seconds_total",
-		"process_resident_memory_bytes",
-		"workqueue_adds_total",
-		"workqueue_depth",
-		"workqueue_queue_duration_seconds_bucket",
-	}
+var dashboardMetrics = []string{
+	"apiserver_request:availability30d",
+	"apiserver_request_total",
+	"cluster_quantile:apiserver_request_duration_seconds:histogram_quantile",
+	"code_resource:apiserver_request_total:rate5m",
+	"go_goroutines",
+	"process_cpu_seconds_total",
+	"process_resident_memory_bytes",
+	"workqueue_adds_total",
+	"workqueue_depth",
+	"workqueue_queue_duration_seconds_bucket",
+}
 
+func TestParseMetricsInBoard(t *testing.T) {
 	var board sdk.Board
 	output := &analyse.MetricsInGrafana{}
 	output.OverallMetrics = make(map[string]struct{})
 
 	buf, err := loadFile("testdata/apiserver.json")
-	if err != nil {
-		t.Errorf("Could not load test dashboard file")
-	}
-	if err = json.Unmarshal(buf, &board); err != nil {
-		t.Errorf("Could not deserialize test dashboard file")
-	}
+	require.NoError(t, err)
+
+	err = json.Unmarshal(buf, &board)
+	require.NoError(t, err)
 
 	parseMetricsInBoard(output, board)
-	assert.Equal(t, metrics, output.Dashboards[0].Metrics)
+	assert.Equal(t, dashboardMetrics, output.Dashboards[0].Metrics)
 }

--- a/pkg/commands/analyse_prometheus.go
+++ b/pkg/commands/analyse_prometheus.go
@@ -32,11 +32,12 @@ type PrometheusAnalyseCommand struct {
 }
 
 func (cmd *PrometheusAnalyseCommand) run(k *kingpin.ParseContext) error {
-	hasGrafanaMetrics := false
-	hasRulerMetrics := false
-	grafanaMetrics := analyse.MetricsInGrafana{}
-	rulerMetrics := analyse.MetricsInRuler{}
-	metricsUsed := make([]string, 0)
+	var (
+		hasGrafanaMetrics, hasRulerMetrics = false, false
+		grafanaMetrics                     = analyse.MetricsInGrafana{}
+		rulerMetrics                       = analyse.MetricsInRuler{}
+		metricsUsed                        []string
+	)
 
 	if _, err := os.Stat(cmd.grafanaMetricsFile); err == nil {
 		hasGrafanaMetrics = true

--- a/pkg/commands/analyse_prometheus.go
+++ b/pkg/commands/analyse_prometheus.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/grafana/cortex-tools/pkg/analyse"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -17,6 +16,8 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
 )
 
 type PrometheusAnalyseCommand struct {
@@ -31,7 +32,6 @@ type PrometheusAnalyseCommand struct {
 }
 
 func (cmd *PrometheusAnalyseCommand) run(k *kingpin.ParseContext) error {
-
 	hasGrafanaMetrics := false
 	hasRulerMetrics := false
 	grafanaMetrics := analyse.MetricsInGrafana{}

--- a/pkg/commands/analyse_rulefiles.go
+++ b/pkg/commands/analyse_rulefiles.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"encoding/json"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type RuleFileAnalyseCommand struct {
+	RuleFilesList []string
+	outputFile    string
+}
+
+func (cmd *RuleFileAnalyseCommand) run(k *kingpin.ParseContext) error {
+	output := &analyse.MetricsInRuler{}
+
+	for _, file := range cmd.RuleFilesList {
+		var ruleConf analyse.RuleConfig
+		buf, err := loadFile(file)
+		if err != nil {
+			return err
+		}
+		if err = json.Unmarshal(buf, &ruleConf); err != nil {
+			return (err)
+		}
+		for _, group := range ruleConf.RuleGroups {
+			parseMetricsInRuleGroup(output, group, ruleConf.Namespace)
+		}
+	}
+
+	err := writeOutRuleMetrics(output, cmd.outputFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/commands/analyse_rulefiles.go
+++ b/pkg/commands/analyse_rulefiles.go
@@ -1,10 +1,11 @@
 package commands
 
 import (
-	"github.com/grafana/cortex-tools/pkg/analyse"
-	"github.com/grafana/cortex-tools/pkg/rules"
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
+	"github.com/grafana/cortex-tools/pkg/rules"
 )
 
 type RuleFileAnalyseCommand struct {
@@ -23,7 +24,10 @@ func (cmd *RuleFileAnalyseCommand) run(k *kingpin.ParseContext) error {
 
 	for _, ns := range nss {
 		for _, group := range ns.Groups {
-			parseMetricsInRuleGroup(output, group, ns.Namespace)
+			err := parseMetricsInRuleGroup(output, group, ns.Namespace)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/commands/analyse_rulefiles.go
+++ b/pkg/commands/analyse_rulefiles.go
@@ -14,6 +14,7 @@ type RuleFileAnalyseCommand struct {
 }
 
 func (cmd *RuleFileAnalyseCommand) run(k *kingpin.ParseContext) error {
+
 	output := &analyse.MetricsInRuler{}
 	output.OverallMetrics = make(map[string]struct{})
 

--- a/pkg/commands/analyse_ruler.go
+++ b/pkg/commands/analyse_ruler.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"sort"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
+	"github.com/grafana/cortex-tools/pkg/client"
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
+	"github.com/prometheus/prometheus/promql/parser"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type RulerAnalyseCommand struct {
+	ClientConfig client.Config
+
+	cli *client.CortexClient
+
+	outputFile string
+}
+
+func (cmd *RulerAnalyseCommand) run(k *kingpin.ParseContext) error {
+	output := analyse.MetricsInRuler{}
+	allMetrics := map[string]struct{}{}
+
+	cli, err := client.New(cmd.ClientConfig)
+	if err != nil {
+		return err
+	}
+
+	cmd.cli = cli
+	rules, err := cmd.cli.ListRules(context.Background(), "")
+	if err != nil {
+		log.Fatalf("unable to read rules from cortex, %v", err)
+	}
+
+	for ns := range rules {
+		for _, rg := range rules[ns] {
+			metrics, err := parseMetricsInRuleGroup(ns, rg)
+			// todo
+			if err != nil {
+				log.Fatalf("metrics parse error %v", err)
+			}
+
+			metricsInGroup := make([]string, 0, len(metrics))
+			for metric := range metrics {
+				if metric == "" {
+					continue
+				}
+				metricsInGroup = append(metricsInGroup, metric)
+				allMetrics[metric] = struct{}{}
+			}
+			output.RuleGroups = append(output.RuleGroups, analyse.RuleGroupMetrics{
+				Namespace: ns,
+				GroupName: rg.Name,
+				Metrics:   metricsInGroup,
+			})
+		}
+	}
+
+	metricsUsed := make([]string, 0, len(allMetrics))
+	for metric := range allMetrics {
+		metricsUsed = append(metricsUsed, metric)
+	}
+	sort.Strings(metricsUsed)
+
+	output.MetricsUsed = metricsUsed
+	out, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(cmd.outputFile, out, os.FileMode(int(0666))); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func parseMetricsInRuleGroup(ns string, group rwrulefmt.RuleGroup) (map[string]struct{}, error) {
+	ruleMetrics := map[string]struct{}{}
+	refMetrics := map[string]struct{}{}
+
+	rules := group.Rules
+	for _, rule := range rules {
+		if rule.Record.Value != "" {
+			ruleMetrics[rule.Record.Value] = struct{}{}
+		} else {
+			ruleMetrics[rule.Alert.Value] = struct{}{}
+		}
+
+		query := rule.Expr.Value
+		expr, err := parser.ParseExpr(query)
+		// todo maintain parse errors
+		if err != nil {
+			return refMetrics, err
+		}
+
+		parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+			if n, ok := node.(*parser.VectorSelector); ok {
+				refMetrics[n.Name] = struct{}{}
+			}
+
+			return nil
+		})
+	}
+
+	// should we handle metrics referenced in other RGs?
+	metrics := diff(ruleMetrics, refMetrics)
+	return metrics, nil
+}
+
+func diff(ruleMetrics map[string]struct{}, refMetrics map[string]struct{}) map[string]struct{} {
+	for ruleMetric := range ruleMetrics {
+		if _, ok := refMetrics[ruleMetric]; ok {
+			delete(refMetrics, ruleMetric)
+		}
+	}
+	return refMetrics
+}

--- a/pkg/commands/analyse_ruler.go
+++ b/pkg/commands/analyse_ruler.go
@@ -56,12 +56,13 @@ func (cmd *RulerAnalyseCommand) run(k *kingpin.ParseContext) error {
 }
 
 func parseMetricsInRuleGroup(mir *analyse.MetricsInRuler, group rwrulefmt.RuleGroup, ns string) error {
-	ruleMetrics := map[string]struct{}{}
-	refMetrics := map[string]struct{}{}
-	parseErrors := make([]error, 0)
+	var (
+		ruleMetrics = make(map[string]struct{})
+		refMetrics  = make(map[string]struct{})
+		parseErrors []error
+	)
 
-	rules := group.Rules
-	for _, rule := range rules {
+	for _, rule := range group.Rules {
 		if rule.Record.Value != "" {
 			ruleMetrics[rule.Record.Value] = struct{}{}
 		}
@@ -88,7 +89,9 @@ func parseMetricsInRuleGroup(mir *analyse.MetricsInRuler, group rwrulefmt.RuleGr
 		delete(refMetrics, ruleMetric)
 	}
 
-	metricsInGroup := make([]string, 0, len(refMetrics))
+	var metricsInGroup []string
+	var parseErrs []string
+
 	for metric := range refMetrics {
 		if metric == "" {
 			continue
@@ -98,7 +101,6 @@ func parseMetricsInRuleGroup(mir *analyse.MetricsInRuler, group rwrulefmt.RuleGr
 	}
 	sort.Strings(metricsInGroup)
 
-	parseErrs := make([]string, 0, len(parseErrors))
 	for _, err := range parseErrors {
 		parseErrs = append(parseErrs, err.Error())
 	}
@@ -114,7 +116,7 @@ func parseMetricsInRuleGroup(mir *analyse.MetricsInRuler, group rwrulefmt.RuleGr
 }
 
 func writeOutRuleMetrics(mir *analyse.MetricsInRuler, outputFile string) error {
-	metricsUsed := make([]string, 0, len(mir.OverallMetrics))
+	var metricsUsed []string
 	for metric := range mir.OverallMetrics {
 		metricsUsed = append(metricsUsed, metric)
 	}

--- a/pkg/commands/analyse_ruler.go
+++ b/pkg/commands/analyse_ruler.go
@@ -24,6 +24,7 @@ type RulerAnalyseCommand struct {
 
 func (cmd *RulerAnalyseCommand) run(k *kingpin.ParseContext) error {
 	output := &analyse.MetricsInRuler{}
+	output.OverallMetrics = make(map[string]struct{})
 
 	cli, err := client.New(cmd.ClientConfig)
 	if err != nil {

--- a/pkg/commands/analyse_ruler.go
+++ b/pkg/commands/analyse_ruler.go
@@ -96,6 +96,7 @@ func parseMetricsInRuleGroup(mir *analyse.MetricsInRuler, group rwrulefmt.RuleGr
 		metricsInGroup = append(metricsInGroup, metric)
 		mir.OverallMetrics[metric] = struct{}{}
 	}
+	sort.Strings(metricsInGroup)
 
 	parseErrs := make([]string, 0, len(parseErrors))
 	for _, err := range parseErrors {

--- a/pkg/commands/analyse_rules_test.go
+++ b/pkg/commands/analyse_rules_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func ParseMetricsInRuleFile(t *testing.T) {
+func TestParseMetricsInRuleFile(t *testing.T) {
 	var metrics = []string{
 		"apiserver_request_duration_seconds_bucket",
 		"apiserver_request_duration_seconds_count",

--- a/pkg/commands/analyse_rules_test.go
+++ b/pkg/commands/analyse_rules_test.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/grafana/cortex-tools/pkg/analyse"
+	"github.com/grafana/cortex-tools/pkg/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func ParseMetricsInRuleFile(t *testing.T) {
+	var metrics = []string{
+		"apiserver_request_duration_seconds_bucket",
+		"apiserver_request_duration_seconds_count",
+		"apiserver_request_total",
+		"container_cpu_usage_seconds_total",
+		"container_memory_cache",
+		"container_memory_rss",
+		"container_memory_swap",
+		"container_memory_working_set_bytes",
+		"kube_pod_container_resource_limits",
+		"kube_pod_container_resource_requests",
+		"kube_pod_info",
+		"kube_pod_owner",
+		"kube_pod_status_phase",
+		"kube_replicaset_owner",
+		"kubelet_node_name",
+		"kubelet_pleg_relist_duration_seconds_bucket",
+		"node_cpu_seconds_total",
+		"node_memory_Buffers_bytes",
+		"node_memory_Cached_bytes",
+		"node_memory_MemAvailable_bytes",
+		"node_memory_MemFree_bytes",
+		"node_memory_Slab_bytes",
+		"scheduler_binding_duration_seconds_bucket",
+		"scheduler_e2e_scheduling_duration_seconds_bucket",
+		"scheduler_scheduling_algorithm_duration_seconds_bucket",
+	}
+
+	output := &analyse.MetricsInRuler{}
+	output.OverallMetrics = make(map[string]struct{})
+
+	nss, err := rules.ParseFiles("cortex", []string{"testdata/prometheus_rules.yaml"})
+	if err != nil {
+		t.Errorf("could not parse rules file")
+	}
+
+	for _, ns := range nss {
+		for _, group := range ns.Groups {
+			err := parseMetricsInRuleGroup(output, group, ns.Namespace)
+			if err != nil {
+				t.Errorf("could not parse metrics in rule group")
+			}
+		}
+	}
+	assert.Equal(t, metrics, output.MetricsUsed)
+}

--- a/pkg/commands/analyse_rules_test.go
+++ b/pkg/commands/analyse_rules_test.go
@@ -1,35 +1,69 @@
 package commands
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/grafana/cortex-tools/pkg/analyse"
 	"github.com/grafana/cortex-tools/pkg/rules"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestParseMetricsInRuleFile(t *testing.T) {
-	var metrics = []string{
-		"apiserver_request_duration_seconds_bucket",
-		"apiserver_request_duration_seconds_count",
-		"apiserver_request_total",
-	}
+var metricsInRuleGroup = []string{
+	"apiserver_request_duration_seconds_bucket",
+	"apiserver_request_duration_seconds_count",
+	"apiserver_request_total",
+}
+var allMetricsInRuleTest = []string{
+	"apiserver_request_duration_seconds_bucket",
+	"apiserver_request_duration_seconds_count",
+	"apiserver_request_total",
+	"container_cpu_usage_seconds_total",
+	"container_memory_cache",
+	"container_memory_rss",
+	"container_memory_swap",
+	"container_memory_working_set_bytes",
+	"kube_pod_container_resource_limits",
+	"kube_pod_container_resource_requests",
+	"kube_pod_info",
+	"kube_pod_owner",
+	"kube_pod_status_phase",
+	"kube_replicaset_owner",
+	"kubelet_node_name",
+	"kubelet_pleg_relist_duration_seconds_bucket",
+	"node_cpu_seconds_total",
+	"node_memory_Buffers_bytes",
+	"node_memory_Cached_bytes",
+	"node_memory_MemAvailable_bytes",
+	"node_memory_MemFree_bytes",
+	"node_memory_Slab_bytes",
+	"scheduler_binding_duration_seconds_bucket",
+	"scheduler_e2e_scheduling_duration_seconds_bucket",
+	"scheduler_scheduling_algorithm_duration_seconds_bucket",
+}
 
+func TestParseMetricsInRuleFile(t *testing.T) {
 	output := &analyse.MetricsInRuler{}
 	output.OverallMetrics = make(map[string]struct{})
 
 	nss, err := rules.ParseFiles("cortex", []string{"testdata/prometheus_rules.yaml"})
-	if err != nil {
-		t.Errorf("could not parse rules file")
-	}
+	require.NoError(t, err)
 
 	for _, ns := range nss {
 		for _, group := range ns.Groups {
 			err := parseMetricsInRuleGroup(output, group, ns.Namespace)
-			if err != nil {
-				t.Errorf("could not parse metrics in rule group")
-			}
+			require.NoError(t, err)
 		}
 	}
-	assert.Equal(t, metrics, output.RuleGroups[0].Metrics)
+	// Check first RG
+	assert.Equal(t, metricsInRuleGroup, output.RuleGroups[0].Metrics)
+
+	// Check all metrics
+	var metricsUsed []string
+	for metric := range output.OverallMetrics {
+		metricsUsed = append(metricsUsed, metric)
+	}
+	sort.Strings(metricsUsed)
+	assert.Equal(t, allMetricsInRuleTest, metricsUsed)
 }

--- a/pkg/commands/analyse_rules_test.go
+++ b/pkg/commands/analyse_rules_test.go
@@ -10,31 +10,9 @@ import (
 
 func TestParseMetricsInRuleFile(t *testing.T) {
 	var metrics = []string{
-		"apiserver_request_duration_seconds_bucket",
 		"apiserver_request_duration_seconds_count",
+		"apiserver_request_duration_seconds_bucket",
 		"apiserver_request_total",
-		"container_cpu_usage_seconds_total",
-		"container_memory_cache",
-		"container_memory_rss",
-		"container_memory_swap",
-		"container_memory_working_set_bytes",
-		"kube_pod_container_resource_limits",
-		"kube_pod_container_resource_requests",
-		"kube_pod_info",
-		"kube_pod_owner",
-		"kube_pod_status_phase",
-		"kube_replicaset_owner",
-		"kubelet_node_name",
-		"kubelet_pleg_relist_duration_seconds_bucket",
-		"node_cpu_seconds_total",
-		"node_memory_Buffers_bytes",
-		"node_memory_Cached_bytes",
-		"node_memory_MemAvailable_bytes",
-		"node_memory_MemFree_bytes",
-		"node_memory_Slab_bytes",
-		"scheduler_binding_duration_seconds_bucket",
-		"scheduler_e2e_scheduling_duration_seconds_bucket",
-		"scheduler_scheduling_algorithm_duration_seconds_bucket",
 	}
 
 	output := &analyse.MetricsInRuler{}
@@ -53,5 +31,5 @@ func TestParseMetricsInRuleFile(t *testing.T) {
 			}
 		}
 	}
-	assert.Equal(t, metrics, output.MetricsUsed)
+	assert.Equal(t, metrics, output.RuleGroups[0].Metrics)
 }

--- a/pkg/commands/analyse_rules_test.go
+++ b/pkg/commands/analyse_rules_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestParseMetricsInRuleFile(t *testing.T) {
 	var metrics = []string{
-		"apiserver_request_duration_seconds_count",
 		"apiserver_request_duration_seconds_bucket",
+		"apiserver_request_duration_seconds_count",
 		"apiserver_request_total",
 	}
 

--- a/pkg/commands/overrides_exporter.go
+++ b/pkg/commands/overrides_exporter.go
@@ -140,7 +140,7 @@ func (o *OverridesExporterCommand) updateMetrics(limitsMap map[string]*validatio
 
 func (o *OverridesExporterCommand) run(k *kingpin.ParseContext) error {
 	if o.overridesFilePath == "" {
-		return errors.New("Empty overrides file path")
+		return errors.New("empty overrides file path")
 	}
 
 	// Update the metrics once before starting.

--- a/pkg/commands/testdata/apiserver.json
+++ b/pkg/commands/testdata/apiserver.json
@@ -1,0 +1,1538 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": false,
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "panels": [
+      {
+         "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
+         "datasource": null,
+         "description": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only.",
+         "gridPos": {
+            "h": 2,
+            "w": 24,
+            "x": 0,
+            "y": 0
+         },
+         "id": 2,
+         "mode": "markdown",
+         "span": 12,
+         "title": "Notice",
+         "type": "text"
+      }
+   ],
+   "refresh": "10s",
+   "rows": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "cacheTimeout": null,
+               "colorBackground": false,
+               "colorValue": false,
+               "colors": [
+                  "#299c46",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#d44a3a"
+               ],
+               "datasource": "$datasource",
+               "decimals": 3,
+               "description": "How many percent of requests (both read and write) in 30 days have been answered successfully and fast enough?",
+               "format": "percentunit",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": { },
+               "id": 3,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": "",
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 4,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": false,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": false
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "",
+               "title": "Availability (30d) > 99.000%",
+               "tooltip": {
+                  "shared": false
+               },
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "avg"
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "decimals": 3,
+               "description": "How much error budget is left looking at our 0.990% availability guarantees?",
+               "fill": 10,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 4,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 8,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "100 * (apiserver_request:availability30d{verb=\"all\", cluster=\"$cluster\"} - 0.990000)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "errorbudget",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "ErrorBudget (30d) > 99.000%",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": false,
+         "title": "Dashboard Row",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "cacheTimeout": null,
+               "colorBackground": false,
+               "colorValue": false,
+               "colors": [
+                  "#299c46",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#d44a3a"
+               ],
+               "datasource": "$datasource",
+               "decimals": 3,
+               "description": "How many percent of read requests (LIST,GET) in 30 days have been answered successfully and fast enough?",
+               "format": "percentunit",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": { },
+               "id": 5,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": "",
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 3,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": false,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": false
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "apiserver_request:availability30d{verb=\"read\", cluster=\"$cluster\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "",
+               "title": "Read Availability (30d)",
+               "tooltip": {
+                  "shared": false
+               },
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "avg"
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
+               "fill": 10,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 6,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "/2../i",
+                     "color": "#56A64B"
+                  },
+                  {
+                     "alias": "/3../i",
+                     "color": "#F2CC0C"
+                  },
+                  {
+                     "alias": "/4../i",
+                     "color": "#3274D9"
+                  },
+                  {
+                     "alias": "/5../i",
+                     "color": "#E02F44"
+                  }
+               ],
+               "spaceLength": 10,
+               "span": 3,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ code }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Read SLI - Requests",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "reqps",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "reqps",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 7,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 3,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"read\", cluster=\"$cluster\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ resource }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Read SLI - Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 8,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 3,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb=\"read\", cluster=\"$cluster\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ resource }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Read SLI - Duration",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": false,
+         "title": "Dashboard Row",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "cacheTimeout": null,
+               "colorBackground": false,
+               "colorValue": false,
+               "colors": [
+                  "#299c46",
+                  "rgba(237, 129, 40, 0.89)",
+                  "#d44a3a"
+               ],
+               "datasource": "$datasource",
+               "decimals": 3,
+               "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) in 30 days have been answered successfully and fast enough?",
+               "format": "percentunit",
+               "gauge": {
+                  "maxValue": 100,
+                  "minValue": 0,
+                  "show": false,
+                  "thresholdLabels": false,
+                  "thresholdMarkers": true
+               },
+               "gridPos": { },
+               "id": 9,
+               "interval": null,
+               "links": [ ],
+               "mappingType": 1,
+               "mappingTypes": [
+                  {
+                     "name": "value to text",
+                     "value": 1
+                  },
+                  {
+                     "name": "range to text",
+                     "value": 2
+                  }
+               ],
+               "maxDataPoints": 100,
+               "nullPointMode": "connected",
+               "nullText": null,
+               "postfix": "",
+               "postfixFontSize": "50%",
+               "prefix": "",
+               "prefixFontSize": "50%",
+               "rangeMaps": [
+                  {
+                     "from": "null",
+                     "text": "N/A",
+                     "to": "null"
+                  }
+               ],
+               "span": 3,
+               "sparkline": {
+                  "fillColor": "rgba(31, 118, 189, 0.18)",
+                  "full": false,
+                  "lineColor": "rgb(31, 120, 193)",
+                  "show": false
+               },
+               "tableColumn": "",
+               "targets": [
+                  {
+                     "expr": "apiserver_request:availability30d{verb=\"write\", cluster=\"$cluster\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": "",
+               "title": "Write Availability (30d)",
+               "tooltip": {
+                  "shared": false
+               },
+               "type": "singlestat",
+               "valueFontSize": "80%",
+               "valueMaps": [
+                  {
+                     "op": "=",
+                     "text": "N/A",
+                     "value": "null"
+                  }
+               ],
+               "valueName": "avg"
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
+               "fill": 10,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 10,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [
+                  {
+                     "alias": "/2../i",
+                     "color": "#56A64B"
+                  },
+                  {
+                     "alias": "/3../i",
+                     "color": "#F2CC0C"
+                  },
+                  {
+                     "alias": "/4../i",
+                     "color": "#3274D9"
+                  },
+                  {
+                     "alias": "/5../i",
+                     "color": "#E02F44"
+                  }
+               ],
+               "spaceLength": 10,
+               "span": 3,
+               "stack": true,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (code) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ code }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Write SLI - Requests",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "reqps",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "reqps",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 11,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 3,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\",code=~\"5..\", cluster=\"$cluster\"}) / sum by (resource) (code_resource:apiserver_request_total:rate5m{verb=\"write\", cluster=\"$cluster\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ resource }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Write SLI - Errors",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 12,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 3,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{verb=\"write\", cluster=\"$cluster\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ resource }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Write SLI - Duration",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": false,
+         "title": "Dashboard Row",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 13,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(workqueue_adds_total{job=\"kube-apiserver\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}} {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Work Queue Add Rate",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "ops",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "ops",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 14,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 6,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(workqueue_depth{job=\"kube-apiserver\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}} {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Work Queue Depth",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 15,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": true,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 12,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{job=\"kube-apiserver\", instance=~\"$instance\", cluster=\"$cluster\"}[5m])) by (instance, name, le))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}} {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Work Queue Latency",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": false,
+         "title": "Dashboard Row",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 16,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "process_resident_memory_bytes{job=\"kube-apiserver\",instance=~\"$instance\", cluster=\"$cluster\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 17,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(process_cpu_seconds_total{job=\"kube-apiserver\",instance=~\"$instance\", cluster=\"$cluster\"}[5m])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU usage",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$datasource",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 18,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_goroutines{job=\"kube-apiserver\",instance=~\"$instance\", cluster=\"$cluster\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{instance}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Goroutines",
+               "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": false,
+         "title": "Dashboard Row",
+         "titleSize": "h6",
+         "type": "row"
+      }
+   ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "kubernetes-mixin"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "default",
+               "value": "default"
+            },
+            "hide": 0,
+            "label": null,
+            "name": "datasource",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 2,
+            "includeAll": false,
+            "label": "cluster",
+            "multi": false,
+            "name": "cluster",
+            "options": [ ],
+            "query": "label_values(apiserver_request_total, cluster)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$datasource",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": false,
+            "name": "instance",
+            "options": [ ],
+            "query": "label_values(apiserver_request_total{job=\"kube-apiserver\", cluster=\"$cluster\"}, instance)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "UTC",
+   "title": "Kubernetes / API server",
+   "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
+   "version": 0
+}

--- a/pkg/commands/testdata/prometheus_rules.yaml
+++ b/pkg/commands/testdata/prometheus_rules.yaml
@@ -1,0 +1,709 @@
+"groups":
+- "name": "kube-apiserver.rules"
+  "rules":
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
+          -
+          (
+            (
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1d]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[1d]))
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[1d]))
+          )
+        )
+        +
+        # errors
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[1d]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[1d]))
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:burnrate1d"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[1h]))
+          -
+          (
+            (
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[1h]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[1h]))
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[1h]))
+          )
+        )
+        +
+        # errors
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[1h]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[1h]))
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:burnrate1h"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[2h]))
+          -
+          (
+            (
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[2h]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[2h]))
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[2h]))
+          )
+        )
+        +
+        # errors
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[2h]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[2h]))
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:burnrate2h"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[30m]))
+          -
+          (
+            (
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30m]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30m]))
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30m]))
+          )
+        )
+        +
+        # errors
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[30m]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[30m]))
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:burnrate30m"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[3d]))
+          -
+          (
+            (
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[3d]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[3d]))
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[3d]))
+          )
+        )
+        +
+        # errors
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[3d]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[3d]))
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:burnrate3d"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+          -
+          (
+            (
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[5m]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[5m]))
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[5m]))
+          )
+        )
+        +
+        # errors
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[5m]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:burnrate5m"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[6h]))
+          -
+          (
+            (
+              sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[6h]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[6h]))
+            +
+            sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[6h]))
+          )
+        )
+        +
+        # errors
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET",code=~"5.."}[6h]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[6h]))
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:burnrate6h"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+          -
+          sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1d]))
+        )
+        +
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1d]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1d]))
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:burnrate1d"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+          -
+          sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[1h]))
+        )
+        +
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[1h]))
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:burnrate1h"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+          -
+          sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[2h]))
+        )
+        +
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[2h]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[2h]))
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:burnrate2h"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+          -
+          sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[30m]))
+        )
+        +
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[30m]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[30m]))
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:burnrate30m"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+          -
+          sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[3d]))
+        )
+        +
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[3d]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[3d]))
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:burnrate3d"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+          -
+          sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[5m]))
+        )
+        +
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[5m]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:burnrate5m"
+  - "expr": |
+      (
+        (
+          # too slow
+          sum by (cluster) (rate(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+          -
+          sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",le="1"}[6h]))
+        )
+        +
+        sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE",code=~"5.."}[6h]))
+      )
+      /
+      sum by (cluster) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[6h]))
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:burnrate6h"
+  - "expr": |
+      sum by (cluster,code,resource) (rate(apiserver_request_total{job="kube-apiserver",verb=~"LIST|GET"}[5m]))
+    "labels":
+      "verb": "read"
+    "record": "code_resource:apiserver_request_total:rate5m"
+  - "expr": |
+      sum by (cluster,code,resource) (rate(apiserver_request_total{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+    "labels":
+      "verb": "write"
+    "record": "code_resource:apiserver_request_total:rate5m"
+  - "expr": |
+      histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET"}[5m]))) > 0
+    "labels":
+      "quantile": "0.99"
+      "verb": "read"
+    "record": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile" 
+- "name": "kube-apiserver2rules"
+  "rules":
+  - "expr": |
+      histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))) > 0
+    "labels":
+      "quantile": "0.99"
+      "verb": "write"
+    "record": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.99"
+    "record": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.9"
+    "record": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="kube-apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.5"
+    "record": "cluster_quantile:apiserver_request_duration_seconds:histogram_quantile"
+- "interval": "3m"
+  "name": "kube-apiserver-availability.rules"
+  "rules":
+  - "expr": |
+      1 - (
+        (
+          # write too slow
+          sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
+          -
+          sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
+        ) +
+        (
+          # read too slow
+          sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~"LIST|GET"}[30d]))
+          -
+          (
+            (
+              sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d]))
+              or
+              vector(0)
+            )
+            +
+            sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="namespace",le="0.5"}[30d]))
+            +
+            sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+          )
+        ) +
+        # errors
+        sum by (cluster) (code:apiserver_request_total:increase30d{code=~"5.."} or vector(0))
+      )
+      /
+      sum by (cluster) (code:apiserver_request_total:increase30d)
+    "labels":
+      "verb": "all"
+    "record": "apiserver_request:availability30d"
+  - "expr": |
+      1 - (
+        sum by (cluster) (increase(apiserver_request_duration_seconds_count{job="kube-apiserver",verb=~"LIST|GET"}[30d]))
+        -
+        (
+          # too slow
+          (
+            sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope=~"resource|",le="0.1"}[30d]))
+            or
+            vector(0)
+          )
+          +
+          sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="namespace",le="0.5"}[30d]))
+          +
+          sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job="kube-apiserver",verb=~"LIST|GET",scope="cluster",le="5"}[30d]))
+        )
+        +
+        # errors
+        sum by (cluster) (code:apiserver_request_total:increase30d{verb="read",code=~"5.."} or vector(0))
+      )
+      /
+      sum by (cluster) (code:apiserver_request_total:increase30d{verb="read"})
+    "labels":
+      "verb": "read"
+    "record": "apiserver_request:availability30d"
+  - "expr": |
+      1 - (
+        (
+          # too slow
+          sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~"POST|PUT|PATCH|DELETE"}[30d]))
+          -
+          sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~"POST|PUT|PATCH|DELETE",le="1"}[30d]))
+        )
+        +
+        # errors
+        sum by (cluster) (code:apiserver_request_total:increase30d{verb="write",code=~"5.."} or vector(0))
+      )
+      /
+      sum by (cluster) (code:apiserver_request_total:increase30d{verb="write"})
+    "labels":
+      "verb": "write"
+    "record": "apiserver_request:availability30d"
+  - "expr": |
+      avg_over_time(code_verb:apiserver_request_total:increase1h[30d]) * 24 * 30
+    "record": "code_verb:apiserver_request_total:increase30d"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="LIST",code=~"2.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="GET",code=~"2.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="POST",code=~"2.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PUT",code=~"2.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PATCH",code=~"2.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="DELETE",code=~"2.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="LIST",code=~"3.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="GET",code=~"3.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="POST",code=~"3.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PUT",code=~"3.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PATCH",code=~"3.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="DELETE",code=~"3.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="LIST",code=~"4.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="GET",code=~"4.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="POST",code=~"4.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PUT",code=~"4.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PATCH",code=~"4.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="DELETE",code=~"4.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="LIST",code=~"5.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="GET",code=~"5.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="POST",code=~"5.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PUT",code=~"5.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="PATCH",code=~"5.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code, verb) (increase(apiserver_request_total{job="kube-apiserver",verb="DELETE",code=~"5.."}[1h]))
+    "record": "code_verb:apiserver_request_total:increase1h"
+  - "expr": |
+      sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
+    "labels":
+      "verb": "read"
+    "record": "code:apiserver_request_total:increase30d"
+  - "expr": |
+      sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+    "labels":
+      "verb": "write"
+    "record": "code:apiserver_request_total:increase30d"
+- "name": "k8s.rules"
+  "rules":
+  - "expr": |
+      sum by (cluster, namespace, pod, container) (
+        irate(container_cpu_usage_seconds_total{job="cadvisor", image!=""}[5m])
+      ) * on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace, pod) (
+        1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
+      )
+    "record": "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate"
+  - "expr": |
+      container_memory_working_set_bytes{job="cadvisor", image!=""}
+      * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+        max by(namespace, pod, node) (kube_pod_info{node!=""})
+      )
+    "record": "node_namespace_pod_container:container_memory_working_set_bytes"
+  - "expr": |
+      container_memory_rss{job="cadvisor", image!=""}
+      * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+        max by(namespace, pod, node) (kube_pod_info{node!=""})
+      )
+    "record": "node_namespace_pod_container:container_memory_rss"
+  - "expr": |
+      container_memory_cache{job="cadvisor", image!=""}
+      * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+        max by(namespace, pod, node) (kube_pod_info{node!=""})
+      )
+    "record": "node_namespace_pod_container:container_memory_cache"
+  - "expr": |
+      container_memory_swap{job="cadvisor", image!=""}
+      * on (namespace, pod) group_left(node) topk by(namespace, pod) (1,
+        max by(namespace, pod, node) (kube_pod_info{node!=""})
+      )
+    "record": "node_namespace_pod_container:container_memory_swap"
+  - "expr": |
+      sum by (namespace, cluster) (
+          sum by (namespace, pod, cluster) (
+              max by (namespace, pod, container, cluster) (
+                kube_pod_container_resource_requests{resource="memory",job="kube-state-metrics"}
+              ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                kube_pod_status_phase{phase=~"Pending|Running"} == 1
+              )
+          )
+      )
+    "record": "namespace_memory:kube_pod_container_resource_requests:sum"
+  - "expr": |
+      sum by (namespace, cluster) (
+          sum by (namespace, pod, cluster) (
+              max by (namespace, pod, container, cluster) (
+                kube_pod_container_resource_requests{resource="cpu",job="kube-state-metrics"}
+              ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                kube_pod_status_phase{phase=~"Pending|Running"} == 1
+              )
+          )
+      )
+    "record": "namespace_cpu:kube_pod_container_resource_requests:sum"
+  - "expr": |
+      sum by (namespace, cluster) (
+          sum by (namespace, pod, cluster) (
+              max by (namespace, pod, container, cluster) (
+                kube_pod_container_resource_limits{resource="memory",job="kube-state-metrics"}
+              ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                kube_pod_status_phase{phase=~"Pending|Running"} == 1
+              )
+          )
+      )
+    "record": "namespace_memory:kube_pod_container_resource_limits:sum"
+  - "expr": |
+      sum by (namespace, cluster) (
+          sum by (namespace, pod, cluster) (
+              max by (namespace, pod, container, cluster) (
+                kube_pod_container_resource_limits{resource="cpu",job="kube-state-metrics"}
+              ) * on(namespace, pod, cluster) group_left() max by (namespace, pod) (
+                kube_pod_status_phase{phase=~"Pending|Running"} == 1
+              )
+          )
+      )
+    "record": "namespace_cpu:kube_pod_container_resource_limits:sum"
+  - "expr": |
+      max by (cluster, namespace, workload, pod) (
+        label_replace(
+          label_replace(
+            kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
+            "replicaset", "$1", "owner_name", "(.*)"
+          ) * on(replicaset, namespace) group_left(owner_name) topk by(replicaset, namespace) (
+            1, max by (replicaset, namespace, owner_name) (
+              kube_replicaset_owner{job="kube-state-metrics"}
+            )
+          ),
+          "workload", "$1", "owner_name", "(.*)"
+        )
+      )
+    "labels":
+      "workload_type": "deployment"
+    "record": "namespace_workload_pod:kube_pod_owner:relabel"
+  - "expr": |
+      max by (cluster, namespace, workload, pod) (
+        label_replace(
+          kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
+          "workload", "$1", "owner_name", "(.*)"
+        )
+      )
+    "labels":
+      "workload_type": "daemonset"
+    "record": "namespace_workload_pod:kube_pod_owner:relabel"
+  - "expr": |
+      max by (cluster, namespace, workload, pod) (
+        label_replace(
+          kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
+          "workload", "$1", "owner_name", "(.*)"
+        )
+      )
+    "labels":
+      "workload_type": "statefulset"
+    "record": "namespace_workload_pod:kube_pod_owner:relabel"
+- "name": "kube-scheduler.rules"
+  "rules":
+  - "expr": |
+      histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.99"
+    "record": "cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.99"
+    "record": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.99"
+    "record": "cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.9"
+    "record": "cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.9"
+    "record": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.9"
+    "record": "cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.5"
+    "record": "cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.5"
+    "record": "cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+    "labels":
+      "quantile": "0.5"
+    "record": "cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile"
+- "name": "node.rules"
+  "rules":
+  - "expr": |
+      topk by(namespace, pod) (1,
+        max by (node, namespace, pod) (
+          label_replace(kube_pod_info{job="kube-state-metrics",node!=""}, "pod", "$1", "pod", "(.*)")
+      ))
+    "record": "node_namespace_pod:kube_pod_info:"
+  - "expr": |
+      count by (cluster, node) (sum by (node, cpu) (
+        node_cpu_seconds_total{job="node-exporter"}
+      * on (namespace, pod) group_left(node)
+        topk by(namespace, pod) (1, node_namespace_pod:kube_pod_info:)
+      ))
+    "record": "node:node_num_cpu:sum"
+  - "expr": |
+      sum(
+        node_memory_MemAvailable_bytes{job="node-exporter"} or
+        (
+          node_memory_Buffers_bytes{job="node-exporter"} +
+          node_memory_Cached_bytes{job="node-exporter"} +
+          node_memory_MemFree_bytes{job="node-exporter"} +
+          node_memory_Slab_bytes{job="node-exporter"}
+        )
+      ) by (cluster)
+    "record": ":node_memory_MemAvailable_bytes:sum"
+- "name": "kubelet.rules"
+  "rules":
+  - "expr": |
+      histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="kubelet"})
+    "labels":
+      "quantile": "0.99"
+    "record": "node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="kubelet"})
+    "labels":
+      "quantile": "0.9"
+    "record": "node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile"
+  - "expr": |
+      histogram_quantile(0.5, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m])) by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="kubelet"})
+    "labels":
+      "quantile": "0.5"
+    "record": "node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile"


### PR DESCRIPTION
- Adds the following:
  - `analyse ruler`
  - `analyse dashboards` (JSON dashboard input)
  - `analyse rule-files` (YAML rule file input)
- Modifies `analyse prometheus` to accept input from `analyse ruler` and `analyse rule-file` output
- Fixes a bug to iterate over sub panels of a `row` type Panel
- Adds two simple tests for extracting metrics
- Adds metric extraction from `templating` sections of dashboard files

(note) Also see https://github.com/grafana-tools/sdk/pull/159 which fixes a deserializing error for the `Decimals` field that I discovered (this is an existing bug, not a new one)