### PR TITLE
[e2ealerting] Support pass through labels & custom histogram buckets

### DIFF
--- a/pkg/alerting/receiver.go
+++ b/pkg/alerting/receiver.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cortexproject/cortex/pkg/util/flagext"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
@@ -20,8 +21,15 @@ import (
 )
 
 const (
-	namespace = "e2ealerting"
+	namespace      = "e2ealerting"
+	alertnameLabel = "alertname"
 )
+
+type timestampKey struct {
+	timestamp   float64
+	alertName   string
+	labelValues string
+}
 
 // Receiver implements the Alertmanager webhook receiver. It evaluates the received alerts, finds if the alert holds an annonnation with a label of "time", and if it does computes now - time for a total duration.
 type Receiver struct {
@@ -29,7 +37,7 @@ type Receiver struct {
 	cfg    ReceiverConfig
 
 	mtx        sync.Mutex
-	timestamps map[float64]struct{}
+	timestamps map[timestampKey]struct{}
 
 	quit chan struct{}
 	wg   sync.WaitGroup
@@ -42,9 +50,10 @@ type Receiver struct {
 
 // ReceiverConfig implements the configuration for the alertmanager webhook receiver
 type ReceiverConfig struct {
-	RoundtripLabel string
-	PurgeLookback  time.Duration
-	PurgeInterval  time.Duration
+	LabelsToForward flagext.StringSliceCSV
+	PurgeInterval   time.Duration
+	PurgeLookback   time.Duration
+	RoundtripLabel  string
 }
 
 // RegisterFlags registers the flags for the alertmanager webhook receiver
@@ -52,11 +61,12 @@ func (cfg *ReceiverConfig) RegisterFlags(f *flag.FlagSet) {
 	f.StringVar(&cfg.RoundtripLabel, "receiver.e2eduration-label", "", "Label name and value in the form 'name=value' to add for the Histogram that observes latency.")
 	f.DurationVar(&cfg.PurgeInterval, "receiver.purge-interval", 15*time.Minute, "How often should we purge the in-memory measured timestamps tracker.")
 	f.DurationVar(&cfg.PurgeLookback, "receiver.purge-lookback", 2*time.Hour, "Period at which measured timestamps will remain in-memory.")
+	f.Var(&cfg.LabelsToForward, "receiver.labels-to-forward", "Additional labels to split alerts by.")
 }
 
 // NewReceiver returns an alertmanager webhook receiver
 func NewReceiver(cfg ReceiverConfig, log log.Logger, reg prometheus.Registerer) (*Receiver, error) {
-	lbl := make(map[string]string, 1)
+	constLabels := make(map[string]string, 1)
 	if cfg.RoundtripLabel != "" {
 		l := strings.Split(cfg.RoundtripLabel, "=")
 
@@ -64,13 +74,21 @@ func NewReceiver(cfg ReceiverConfig, log log.Logger, reg prometheus.Registerer) 
 			return nil, fmt.Errorf("the label is not valid, it must have exactly one name and one value: %s has %d parts", l, len(l))
 		}
 
-		lbl[l[0]] = l[1]
+		constLabels[l[0]] = l[1]
+	}
+
+	labelNames := make([]string, 1+len(cfg.LabelsToForward))
+	labelNames[0] = alertnameLabel
+	if len(cfg.LabelsToForward) > 0 {
+		for i, nm := range cfg.LabelsToForward {
+			labelNames[i+1] = nm
+		}
 	}
 
 	r := &Receiver{
 		logger:     log,
 		cfg:        cfg,
-		timestamps: map[float64]struct{}{},
+		timestamps: map[timestampKey]struct{}{},
 		registry:   reg,
 	}
 
@@ -94,8 +112,8 @@ func NewReceiver(cfg ReceiverConfig, log log.Logger, reg prometheus.Registerer) 
 		Name:        "end_to_end_duration_seconds",
 		Help:        "Time spent (in seconds) from scraping a metric to receiving an alert.",
 		Buckets:     []float64{5, 15, 30, 60, 90, 120, 240},
-		ConstLabels: lbl,
-	}, []string{"alertname"})
+		ConstLabels: constLabels,
+	}, labelNames)
 
 	r.wg.Add(1)
 	go r.purgeTimestamps()
@@ -123,13 +141,24 @@ func (r *Receiver) measureLatency(w http.ResponseWriter, req *http.Request) {
 
 	// We only care about firing alerts as part of this analysis.
 	for _, alert := range data.Alerts.Firing() {
+		var labelValues strings.Builder
+		labels := map[string]string{}
+
 		var name string
 		for k, v := range alert.Labels {
+			for _, lblName := range r.cfg.LabelsToForward {
+				if lblName == k {
+					labelValues.WriteString(v)
+					labels[k] = v
+				}
+			}
+
 			if k != model.AlertNameLabel {
 				continue
 			}
 
 			name = v
+			labels[alertnameLabel] = v
 		}
 
 		if name == "" {
@@ -158,18 +187,32 @@ func (r *Receiver) measureLatency(w http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
+		// fill in any missing label values that were not provided by AM
+		// otherwise the Prom pkg is unhappy
+		for _, k := range r.cfg.LabelsToForward {
+			if _, ok := labels[k]; !ok {
+				labels[k] = ""
+			}
+		}
+
+		key := timestampKey{
+			timestamp:   t,
+			alertName:   name,
+			labelValues: labelValues.String(),
+		}
+
 		latency := now.Unix() - int64(t)
 		r.mtx.Lock()
-		if _, exists := r.timestamps[t]; exists {
-			// We have seen this timestamp before, skip it.
-			level.Debug(r.logger).Log("msg", "timestamp previously evaluated", "timestamp", t, "alert", name)
+		if _, exists := r.timestamps[key]; exists {
+			// We have seen this entry before, skip it.
+			level.Debug(r.logger).Log("msg", "entry previously evaluated", "timestamp", t, "alert", name)
 			r.mtx.Unlock()
 			continue
 		}
-		r.timestamps[t] = struct{}{}
+		r.timestamps[key] = struct{}{}
 		r.mtx.Unlock()
 
-		r.roundtripDuration.WithLabelValues(name).Observe(float64(latency))
+		r.roundtripDuration.With(labels).Observe(float64(latency))
 		level.Info(r.logger).Log("alert", name, "time", time.Unix(int64(t), 0), "duration_seconds", latency, "status", alert.Status)
 		r.evalTotal.Inc()
 	}
@@ -193,10 +236,10 @@ func (r *Receiver) purgeTimestamps() {
 
 			r.mtx.Lock()
 			var deleted int
-			for t := range r.timestamps {
+			for k := range r.timestamps {
 				// purge entry for the timestamp, when the deadline is after the timestamp t
-				if deadline.After(time.Unix(int64(t), 0)) {
-					delete(r.timestamps, t)
+				if deadline.After(time.Unix(int64(k.timestamp), 0)) {
+					delete(r.timestamps, k)
 					deleted++
 				}
 			}

--- a/pkg/alerting/receiver.go
+++ b/pkg/alerting/receiver.go
@@ -143,6 +143,11 @@ func NewReceiver(cfg ReceiverConfig, log log.Logger, reg prometheus.Registerer) 
 // RegisterRoutes registers the receiver API routes with the provided router.
 func (r *Receiver) RegisterRoutes(router *mux.Router) {
 	router.Path("/api/v1/receiver").Methods(http.MethodPost).Handler(http.HandlerFunc(r.measureLatency))
+	router.Path("/health").Methods(http.MethodGet).Handler(http.HandlerFunc(r.health))
+}
+
+func (r *Receiver) health(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }
 
 func (r *Receiver) measureLatency(w http.ResponseWriter, req *http.Request) {

--- a/pkg/alerting/receiver.go
+++ b/pkg/alerting/receiver.go
@@ -205,7 +205,7 @@ func (r *Receiver) measureLatency(w http.ResponseWriter, req *http.Request) {
 		r.mtx.Lock()
 		if _, exists := r.timestamps[key]; exists {
 			// We have seen this entry before, skip it.
-			level.Debug(r.logger).Log("msg", "entry previously evaluated", "timestamp", t, "alert", name)
+			level.Debug(r.logger).Log("msg", "entry previously evaluated", "timestamp", t, "alert", name, "labelValues", key.labelValues)
 			r.mtx.Unlock()
 			continue
 		}

--- a/pkg/alerting/receiver.go
+++ b/pkg/alerting/receiver.go
@@ -233,7 +233,7 @@ func (r *Receiver) measureLatency(w http.ResponseWriter, req *http.Request) {
 		r.mtx.Unlock()
 
 		r.roundtripDuration.With(labels).Observe(float64(latency))
-		level.Info(r.logger).Log("alert", name, "time", time.Unix(int64(t), 0), "duration_seconds", latency, "status", alert.Status)
+		level.Info(r.logger).Log("alert", name, "labelValues", key.labelValues, "time", time.Unix(int64(t), 0), "duration_seconds", latency, "status", alert.Status)
 		r.evalTotal.Inc()
 	}
 

--- a/pkg/alerting/receiver.go
+++ b/pkg/alerting/receiver.go
@@ -160,9 +160,7 @@ func (r *Receiver) measureLatency(w http.ResponseWriter, req *http.Request) {
 
 	// We only care about firing alerts as part of this analysis.
 	for _, alert := range data.Alerts.Firing() {
-
 		labels := map[string]string{}
-
 		var name string
 		for k, v := range alert.Labels {
 			for _, lblName := range r.cfg.LabelsToForward {

--- a/pkg/alerting/receiver_test.go
+++ b/pkg/alerting/receiver_test.go
@@ -22,7 +22,7 @@ func Test_measureLatency(t *testing.T) {
 		name    string
 		alerts  template.Data
 		err     error
-		tracked []float64
+		tracked []timestampKey
 	}{
 		{
 			name: "with alerts to track",
@@ -33,6 +33,18 @@ func Test_measureLatency(t *testing.T) {
 						Annotations: template.KV{"time": "1.604069614e+09"},
 						Status:      string(model.AlertFiring),
 					},
+					// duplicate alert, will be ignored
+					template.Alert{
+						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring"},
+						Annotations: template.KV{"time": "1.604069614e+09"},
+						Status:      string(model.AlertFiring),
+					},
+					// different alert at same time
+					template.Alert{
+						Labels:      template.KV{model.AlertNameLabel: "ADifferentAlertAtTheSameTime"},
+						Annotations: template.KV{"time": "1.604069614e+09"},
+						Status:      string(model.AlertFiring),
+					},
 					template.Alert{
 						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring"},
 						Annotations: template.KV{"time": "1.604069615e+09"},
@@ -40,7 +52,23 @@ func Test_measureLatency(t *testing.T) {
 					},
 				},
 			},
-			tracked: []float64{1604069614.00, 1604069615.00},
+			tracked: []timestampKey{
+				{
+					alertName:   "e2ealertingAlwaysFiring",
+					labelValues: "",
+					timestamp:   1604069614.00,
+				},
+				{
+					alertName:   "ADifferentAlertAtTheSameTime",
+					labelValues: "",
+					timestamp:   1604069614.00,
+				},
+				{
+					alertName:   "e2ealertingAlwaysFiring",
+					labelValues: "",
+					timestamp:   1604069615.00,
+				},
+			},
 		},
 		{
 			name: "with alerts that don't have a time annotation or alertname label it ignores them",
@@ -61,7 +89,7 @@ func Test_measureLatency(t *testing.T) {
 					},
 				},
 			},
-			tracked: []float64{1604069614.00},
+			tracked: []timestampKey{{alertName: "e2ealertingAlwaysFiring", labelValues: "", timestamp: 1604069614.00}},
 		},
 	}
 
@@ -87,9 +115,118 @@ func Test_measureLatency(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, w.Code)
 			require.Equal(t, len(tt.tracked), len(r.timestamps))
-			for _, timestamp := range tt.tracked {
-				_, exists := r.timestamps[timestamp]
-				require.True(t, exists, fmt.Sprintf("time %f is not tracked", timestamp))
+			for _, key := range tt.tracked {
+				_, exists := r.timestamps[key]
+				require.True(t, exists, fmt.Sprintf("time %f is not tracked", key.timestamp))
+			}
+		})
+	}
+}
+
+func Test_measureLatencyWithAdditionalLabels(t *testing.T) {
+	tc := []struct {
+		name    string
+		alerts  template.Data
+		err     error
+		tracked []timestampKey
+	}{
+		{
+			name: "with alerts to track",
+			alerts: template.Data{
+				Alerts: template.Alerts{
+					template.Alert{
+						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring", "region": "us-east-1"},
+						Annotations: template.KV{"time": "1.604069614e+09"},
+						Status:      string(model.AlertFiring),
+					},
+					// duplicate alert, will be ignored
+					template.Alert{
+						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring", "region": "us-east-1"},
+						Annotations: template.KV{"time": "1.604069614e+09"},
+						Status:      string(model.AlertFiring),
+					},
+					// different alert at same time
+					template.Alert{
+						Labels:      template.KV{model.AlertNameLabel: "ADifferentAlertAtTheSameTime"},
+						Annotations: template.KV{"time": "1.604069614e+09"},
+						Status:      string(model.AlertFiring),
+					},
+					template.Alert{
+						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring"},
+						Annotations: template.KV{"time": "1.604069615e+09"},
+						Status:      string(model.AlertFiring),
+					},
+				},
+			},
+			tracked: []timestampKey{
+				{
+					alertName:   "e2ealertingAlwaysFiring",
+					labelValues: "us-east-1",
+					timestamp:   1604069614.00,
+				},
+				{
+					alertName:   "ADifferentAlertAtTheSameTime",
+					labelValues: "",
+					timestamp:   1604069614.00,
+				},
+				{
+					alertName:   "e2ealertingAlwaysFiring",
+					labelValues: "",
+					timestamp:   1604069615.00,
+				},
+			},
+		},
+		{
+			name: "with alerts that don't have a time annotation or alertname label it ignores them",
+			alerts: template.Data{
+				Alerts: template.Alerts{
+					template.Alert{
+						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring"},
+						Annotations: template.KV{"time": "1.604069614e+09"},
+						Status:      string(model.AlertFiring),
+					},
+					template.Alert{
+						Labels: template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring"},
+						Status: string(model.AlertFiring),
+					},
+					template.Alert{
+						Annotations: template.KV{"time": "1.604069614e+09"},
+						Status:      string(model.AlertFiring),
+					},
+				},
+			},
+			tracked: []timestampKey{{alertName: "e2ealertingAlwaysFiring", labelValues: "", timestamp: 1604069614.00}},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewReceiver(
+				ReceiverConfig{
+					PurgeInterval:   1 * time.Hour,
+					LabelsToForward: []string{"region"},
+				},
+				log.NewNopLogger(),
+				prometheus.NewRegistry(),
+			)
+			require.NoError(t, err)
+
+			router := mux.NewRouter()
+			r.RegisterRoutes(router)
+
+			b, err := json.Marshal(tt.alerts)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/receiver", bytes.NewBuffer(b))
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, len(tt.tracked), len(r.timestamps))
+			for _, key := range tt.tracked {
+				_, exists := r.timestamps[key]
+				require.True(t, exists, fmt.Sprintf("time %f is not tracked", key.timestamp))
 			}
 		})
 	}

--- a/pkg/alerting/receiver_test.go
+++ b/pkg/alerting/receiver_test.go
@@ -147,12 +147,12 @@ func Test_measureLatencyWithAdditionalLabels(t *testing.T) {
 					},
 					// different alert at same time
 					template.Alert{
-						Labels:      template.KV{model.AlertNameLabel: "ADifferentAlertAtTheSameTime"},
+						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring", "region": "us-west-1"},
 						Annotations: template.KV{"time": "1.604069614e+09"},
 						Status:      string(model.AlertFiring),
 					},
 					template.Alert{
-						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring"},
+						Labels:      template.KV{model.AlertNameLabel: "e2ealertingAlwaysFiring", "region": "us-east-1"},
 						Annotations: template.KV{"time": "1.604069615e+09"},
 						Status:      string(model.AlertFiring),
 					},
@@ -165,13 +165,13 @@ func Test_measureLatencyWithAdditionalLabels(t *testing.T) {
 					timestamp:   1604069614.00,
 				},
 				{
-					alertName:   "ADifferentAlertAtTheSameTime",
-					labelValues: "",
+					alertName:   "e2ealertingAlwaysFiring",
+					labelValues: "us-west-1",
 					timestamp:   1604069614.00,
 				},
 				{
 					alertName:   "e2ealertingAlwaysFiring",
-					labelValues: "",
+					labelValues: "us-east-1",
 					timestamp:   1604069615.00,
 				},
 			},


### PR DESCRIPTION
We're using e2ealerting across our k8s fleet to monitor latency from ingestor to AM and want to be able to break that down by specific tags like cluster name or AZ. We could solve this by generating one rule for each but this becomes harder to manage as our cluster grows automatically. Instead this adds the ability to pass through custom labels from AM to the histogram and improves the timestamp seen logic to track this by the particular facets.

It also provides customization for the histogram buckets for those that want to get more granular on specific details.