### PR TITLE
add tags filtering for search grafana dashboards

### DIFF
--- a/pkg/commands/analyse.go
+++ b/pkg/commands/analyse.go
@@ -48,6 +48,9 @@ func (cmd *AnalyseCommand) Register(app *kingpin.Application) {
 		Envar("GRAFANA_API_KEY").
 		Default("").
 		StringVar(&gaCmd.apiKey)
+	grafanaAnalyseCmd.Flag("tags", "Tags used for filtering dashboards for alanyse, seperate multiple tags with comma").
+		Default("").
+		StringVar(&gaCmd.tags)
 	grafanaAnalyseCmd.Flag("read-timeout", "timeout for read requests").
 		Default("300s").
 		DurationVar(&gaCmd.readTimeout)

--- a/pkg/commands/analyse_grafana.go
+++ b/pkg/commands/analyse_grafana.go
@@ -24,8 +24,8 @@ type GrafanaAnalyseCommand struct {
 	address     string
 	apiKey      string
 	readTimeout time.Duration
-
-	outputFile string
+	tags        string
+	outputFile  string
 }
 
 func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
@@ -40,7 +40,8 @@ func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
 		return err
 	}
 
-	boardLinks, err := c.SearchDashboards(ctx, "", false)
+	tags := strings.Split(cmd.tags, ",")
+	boardLinks, err := c.SearchDashboards(ctx, "", false, tags...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When search grafana, I find that select dashboards by tags very helpful.
So I think maybe it's a good idea to support this search condition :grin:

Signed-off-by: wangyingtao <wangyingtao@bilibili.com>