### PR TITLE
fix: readme: Correct rules-delete description

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This command will retrieve the specified rule group from Cortex and print it to 
 
 ##### Rules Delete
 
-This command will retrieve the specified rule group from Cortex and print it to the terminal.
+This command will delete the specified rule group from the specified namespace.
 
     cortextool rules delete example_namespace example_rule_group
 


### PR DESCRIPTION
Fixes description mis-copy from `cortextools rules get`.