### PR TITLE
Move analyse command logic to pkg, and export it

### DIFF
--- a/pkg/analyse/grafana.go
+++ b/pkg/analyse/grafana.go
@@ -1,5 +1,18 @@
 package analyse
 
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/grafana-tools/sdk"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
 type MetricsInGrafana struct {
 	MetricsUsed    []string            `json:"metricsUsed"`
 	OverallMetrics map[string]struct{} `json:"-"`
@@ -12,4 +25,139 @@ type DashboardMetrics struct {
 	Title       string   `json:"title"`
 	Metrics     []string `json:"metrics"`
 	ParseErrors []string `json:"parse_errors"`
+}
+
+func ParseMetricsInBoard(mig *MetricsInGrafana, board sdk.Board) {
+	var parseErrors []error
+	metrics := make(map[string]struct{})
+
+	// Iterate through all the panels and collect metrics
+	for _, panel := range board.Panels {
+		parseErrors = append(parseErrors, metricsFromPanel(*panel, metrics)...)
+		if panel.RowPanel != nil {
+			for _, subPanel := range panel.RowPanel.Panels {
+				parseErrors = append(parseErrors, metricsFromPanel(subPanel, metrics)...)
+			}
+		}
+	}
+
+	// Iterate through all the rows and collect metrics
+	for _, row := range board.Rows {
+		for _, panel := range row.Panels {
+			parseErrors = append(parseErrors, metricsFromPanel(panel, metrics)...)
+		}
+	}
+
+	// Process metrics in templating
+	parseErrors = append(parseErrors, metricsFromTemplating(board.Templating, metrics)...)
+
+	var parseErrs []string
+	for _, err := range parseErrors {
+		parseErrs = append(parseErrs, err.Error())
+	}
+
+	var metricsInBoard []string
+	for metric := range metrics {
+		if metric == "" {
+			continue
+		}
+
+		metricsInBoard = append(metricsInBoard, metric)
+		mig.OverallMetrics[metric] = struct{}{}
+	}
+	sort.Strings(metricsInBoard)
+
+	mig.Dashboards = append(mig.Dashboards, DashboardMetrics{
+		Slug:        board.Slug,
+		UID:         board.UID,
+		Title:       board.Title,
+		Metrics:     metricsInBoard,
+		ParseErrors: parseErrs,
+	})
+
+}
+
+func metricsFromTemplating(templating sdk.Templating, metrics map[string]struct{}) []error {
+	parseErrors := []error{}
+	for _, templateVar := range templating.List {
+		if templateVar.Type != "query" {
+			continue
+		}
+		if query, ok := templateVar.Query.(string); ok {
+			// label_values
+			if strings.Contains(query, "label_values") {
+				re := regexp.MustCompile(`label_values\(([a-zA-Z0-9_]+)`)
+				sm := re.FindStringSubmatch(query)
+				// In case of really gross queries, like - https://github.com/grafana/jsonnet-libs/blob/e97ab17f67ab40d5fe3af7e59151dd43be03f631/hass-mixin/dashboard.libsonnet#L93
+				if len(sm) > 0 {
+					query = sm[1]
+				}
+			}
+			// query_result
+			if strings.Contains(query, "query_result") {
+				re := regexp.MustCompile(`query_result\((.+)\)`)
+				query = re.FindStringSubmatch(query)[1]
+			}
+			err := parseQuery(query, metrics)
+			if err != nil {
+				parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
+				log.Debugln("msg", "promql parse error", "err", err, "query", query)
+				continue
+			}
+		} else {
+			err := fmt.Errorf("templating type error: name=%v", templateVar.Name)
+			parseErrors = append(parseErrors, err)
+			log.Debugln("msg", "templating parse error", "err", err)
+			continue
+		}
+	}
+	return parseErrors
+}
+
+func metricsFromPanel(panel sdk.Panel, metrics map[string]struct{}) []error {
+	var parseErrors []error
+
+	if panel.GetTargets() == nil {
+		return parseErrors
+	}
+
+	for _, target := range *panel.GetTargets() {
+		// Prometheus has this set.
+		if target.Expr == "" {
+			continue
+		}
+		query := target.Expr
+		err := parseQuery(query, metrics)
+		if err != nil {
+			parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
+			log.Debugln("msg", "promql parse error", "err", err, "query", query)
+			continue
+		}
+	}
+
+	return parseErrors
+}
+
+func parseQuery(query string, metrics map[string]struct{}) error {
+	query = strings.ReplaceAll(query, `$__interval`, "5m")
+	query = strings.ReplaceAll(query, `$interval`, "5m")
+	query = strings.ReplaceAll(query, `$resolution`, "5s")
+	query = strings.ReplaceAll(query, "$__rate_interval", "15s")
+	query = strings.ReplaceAll(query, "$__range", "1d")
+	query = strings.ReplaceAll(query, "${__range_s:glob}", "30")
+	query = strings.ReplaceAll(query, "${__range_s}", "30")
+	expr, err := parser.ParseExpr(query)
+	if err != nil {
+		return err
+	}
+
+	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+		if n, ok := node.(*parser.VectorSelector); ok {
+			metrics[n.Name] = struct{}{}
+		}
+
+		return nil
+	})
+
+	return nil
 }

--- a/pkg/analyse/ruler.go
+++ b/pkg/analyse/ruler.go
@@ -1,5 +1,14 @@
 package analyse
 
+import (
+	"sort"
+
+	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
+	"github.com/pkg/errors"
+	"github.com/prometheus/prometheus/promql/parser"
+	log "github.com/sirupsen/logrus"
+)
+
 type MetricsInRuler struct {
 	MetricsUsed    []string            `json:"metricsUsed"`
 	OverallMetrics map[string]struct{} `json:"-"`
@@ -11,4 +20,64 @@ type RuleGroupMetrics struct {
 	GroupName   string   `json:"name"`
 	Metrics     []string `json:"metrics"`
 	ParseErrors []string `json:"parse_errors"`
+}
+
+func ParseMetricsInRuleGroup(mir *MetricsInRuler, group rwrulefmt.RuleGroup, ns string) error {
+	var (
+		ruleMetrics = make(map[string]struct{})
+		refMetrics  = make(map[string]struct{})
+		parseErrors []error
+	)
+
+	for _, rule := range group.Rules {
+		if rule.Record.Value != "" {
+			ruleMetrics[rule.Record.Value] = struct{}{}
+		}
+
+		query := rule.Expr.Value
+		expr, err := parser.ParseExpr(query)
+		if err != nil {
+			parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
+			log.Debugln("msg", "promql parse error", "err", err, "query", query)
+			continue
+		}
+
+		parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+			if n, ok := node.(*parser.VectorSelector); ok {
+				refMetrics[n.Name] = struct{}{}
+			}
+
+			return nil
+		})
+	}
+
+	// remove defined recording rule metrics in same RG
+	for ruleMetric := range ruleMetrics {
+		delete(refMetrics, ruleMetric)
+	}
+
+	var metricsInGroup []string
+	var parseErrs []string
+
+	for metric := range refMetrics {
+		if metric == "" {
+			continue
+		}
+		metricsInGroup = append(metricsInGroup, metric)
+		mir.OverallMetrics[metric] = struct{}{}
+	}
+	sort.Strings(metricsInGroup)
+
+	for _, err := range parseErrors {
+		parseErrs = append(parseErrs, err.Error())
+	}
+
+	mir.RuleGroups = append(mir.RuleGroups, RuleGroupMetrics{
+		Namespace:   ns,
+		GroupName:   group.Name,
+		Metrics:     metricsInGroup,
+		ParseErrors: parseErrs,
+	})
+
+	return nil
 }

--- a/pkg/commands/analyse_dashboards.go
+++ b/pkg/commands/analyse_dashboards.go
@@ -30,7 +30,7 @@ func (cmd *DashboardAnalyseCommand) run(k *kingpin.ParseContext) error {
 			fmt.Fprintf(os.Stderr, "%s for %s\n", err, file)
 			continue
 		}
-		parseMetricsInBoard(output, board)
+		analyse.ParseMetricsInBoard(output, board)
 	}
 
 	err := writeOut(output, cmd.outputFile)

--- a/pkg/commands/analyse_grafana.go
+++ b/pkg/commands/analyse_grafana.go
@@ -6,15 +6,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"regexp"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/grafana-tools/sdk"
-	"github.com/pkg/errors"
-	"github.com/prometheus/prometheus/promql/parser"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/cortex-tools/pkg/analyse"
@@ -51,7 +46,7 @@ func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
 			fmt.Fprintf(os.Stderr, "%s for %s %s\n", err, link.UID, link.Title)
 			continue
 		}
-		parseMetricsInBoard(output, board)
+		analyse.ParseMetricsInBoard(output, board)
 	}
 
 	err = writeOut(output, cmd.outputFile)
@@ -78,137 +73,6 @@ func writeOut(mig *analyse.MetricsInGrafana, outputFile string) error {
 	if err := ioutil.WriteFile(outputFile, out, os.FileMode(int(0666))); err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func parseMetricsInBoard(mig *analyse.MetricsInGrafana, board sdk.Board) {
-	var parseErrors []error
-	metrics := make(map[string]struct{})
-
-	// Iterate through all the panels and collect metrics
-	for _, panel := range board.Panels {
-		parseErrors = append(parseErrors, metricsFromPanel(*panel, metrics)...)
-		if panel.RowPanel != nil {
-			for _, subPanel := range panel.RowPanel.Panels {
-				parseErrors = append(parseErrors, metricsFromPanel(subPanel, metrics)...)
-			}
-		}
-	}
-
-	// Iterate through all the rows and collect metrics
-	for _, row := range board.Rows {
-		for _, panel := range row.Panels {
-			parseErrors = append(parseErrors, metricsFromPanel(panel, metrics)...)
-		}
-	}
-
-	// Process metrics in templating
-	parseErrors = append(parseErrors, metricsFromTemplating(board.Templating, metrics)...)
-
-	var parseErrs []string
-	for _, err := range parseErrors {
-		parseErrs = append(parseErrs, err.Error())
-	}
-
-	var metricsInBoard []string
-	for metric := range metrics {
-		if metric == "" {
-			continue
-		}
-
-		metricsInBoard = append(metricsInBoard, metric)
-		mig.OverallMetrics[metric] = struct{}{}
-	}
-	sort.Strings(metricsInBoard)
-
-	mig.Dashboards = append(mig.Dashboards, analyse.DashboardMetrics{
-		Slug:        board.Slug,
-		UID:         board.UID,
-		Title:       board.Title,
-		Metrics:     metricsInBoard,
-		ParseErrors: parseErrs,
-	})
-
-}
-
-func metricsFromTemplating(templating sdk.Templating, metrics map[string]struct{}) []error {
-	parseErrors := []error{}
-	for _, templateVar := range templating.List {
-		if templateVar.Type != "query" {
-			continue
-		}
-		if query, ok := templateVar.Query.(string); ok {
-			// label_values
-			if strings.Contains(query, "label_values") {
-				re := regexp.MustCompile(`label_values\(([a-zA-Z0-9_]+)`)
-				query = re.FindStringSubmatch(query)[1]
-			}
-			// query_result
-			if strings.Contains(query, "query_result") {
-				re := regexp.MustCompile(`query_result\((.+)\)`)
-				query = re.FindStringSubmatch(query)[1]
-			}
-			err := parseQuery(query, metrics)
-			if err != nil {
-				parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
-				log.Debugln("msg", "promql parse error", "err", err, "query", query)
-				continue
-			}
-		} else {
-			err := fmt.Errorf("templating type error: name=%v", templateVar.Name)
-			parseErrors = append(parseErrors, err)
-			log.Debugln("msg", "templating parse error", "err", err)
-			continue
-		}
-	}
-	return parseErrors
-}
-
-func metricsFromPanel(panel sdk.Panel, metrics map[string]struct{}) []error {
-	var parseErrors []error
-
-	if panel.GetTargets() == nil {
-		return parseErrors
-	}
-
-	for _, target := range *panel.GetTargets() {
-		// Prometheus has this set.
-		if target.Expr == "" {
-			continue
-		}
-		query := target.Expr
-		err := parseQuery(query, metrics)
-		if err != nil {
-			parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
-			log.Debugln("msg", "promql parse error", "err", err, "query", query)
-			continue
-		}
-	}
-
-	return parseErrors
-}
-
-func parseQuery(query string, metrics map[string]struct{}) error {
-	query = strings.ReplaceAll(query, `$__interval`, "5m")
-	query = strings.ReplaceAll(query, `$interval`, "5m")
-	query = strings.ReplaceAll(query, `$resolution`, "5s")
-	query = strings.ReplaceAll(query, "$__rate_interval", "15s")
-	query = strings.ReplaceAll(query, "$__range", "1d")
-	query = strings.ReplaceAll(query, "${__range_s:glob}", "30")
-	query = strings.ReplaceAll(query, "${__range_s}", "30")
-	expr, err := parser.ParseExpr(query)
-	if err != nil {
-		return err
-	}
-
-	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
-		if n, ok := node.(*parser.VectorSelector); ok {
-			metrics[n.Name] = struct{}{}
-		}
-
-		return nil
-	})
 
 	return nil
 }

--- a/pkg/commands/analyse_grafana_test.go
+++ b/pkg/commands/analyse_grafana_test.go
@@ -35,6 +35,6 @@ func TestParseMetricsInBoard(t *testing.T) {
 	err = json.Unmarshal(buf, &board)
 	require.NoError(t, err)
 
-	parseMetricsInBoard(output, board)
+	analyse.ParseMetricsInBoard(output, board)
 	assert.Equal(t, dashboardMetrics, output.Dashboards[0].Metrics)
 }

--- a/pkg/commands/analyse_rulefiles.go
+++ b/pkg/commands/analyse_rulefiles.go
@@ -25,7 +25,7 @@ func (cmd *RuleFileAnalyseCommand) run(k *kingpin.ParseContext) error {
 
 	for _, ns := range nss {
 		for _, group := range ns.Groups {
-			err := parseMetricsInRuleGroup(output, group, ns.Namespace)
+			err := analyse.ParseMetricsInRuleGroup(output, group, ns.Namespace)
 			if err != nil {
 				return err
 			}

--- a/pkg/commands/analyse_ruler.go
+++ b/pkg/commands/analyse_ruler.go
@@ -7,14 +7,11 @@ import (
 	"os"
 	"sort"
 
-	"github.com/pkg/errors"
-	"github.com/prometheus/prometheus/promql/parser"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/cortex-tools/pkg/analyse"
 	"github.com/grafana/cortex-tools/pkg/client"
-	"github.com/grafana/cortex-tools/pkg/rules/rwrulefmt"
 )
 
 type RulerAnalyseCommand struct {
@@ -40,7 +37,7 @@ func (cmd *RulerAnalyseCommand) run(k *kingpin.ParseContext) error {
 
 	for ns := range rules {
 		for _, rg := range rules[ns] {
-			err := parseMetricsInRuleGroup(output, rg, ns)
+			err := analyse.ParseMetricsInRuleGroup(output, rg, ns)
 			if err != nil {
 				log.Fatalf("metrics parse error %v", err)
 			}
@@ -51,66 +48,6 @@ func (cmd *RulerAnalyseCommand) run(k *kingpin.ParseContext) error {
 	if err != nil {
 		return err
 	}
-
-	return nil
-}
-
-func parseMetricsInRuleGroup(mir *analyse.MetricsInRuler, group rwrulefmt.RuleGroup, ns string) error {
-	var (
-		ruleMetrics = make(map[string]struct{})
-		refMetrics  = make(map[string]struct{})
-		parseErrors []error
-	)
-
-	for _, rule := range group.Rules {
-		if rule.Record.Value != "" {
-			ruleMetrics[rule.Record.Value] = struct{}{}
-		}
-
-		query := rule.Expr.Value
-		expr, err := parser.ParseExpr(query)
-		if err != nil {
-			parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
-			log.Debugln("msg", "promql parse error", "err", err, "query", query)
-			continue
-		}
-
-		parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
-			if n, ok := node.(*parser.VectorSelector); ok {
-				refMetrics[n.Name] = struct{}{}
-			}
-
-			return nil
-		})
-	}
-
-	// remove defined recording rule metrics in same RG
-	for ruleMetric := range ruleMetrics {
-		delete(refMetrics, ruleMetric)
-	}
-
-	var metricsInGroup []string
-	var parseErrs []string
-
-	for metric := range refMetrics {
-		if metric == "" {
-			continue
-		}
-		metricsInGroup = append(metricsInGroup, metric)
-		mir.OverallMetrics[metric] = struct{}{}
-	}
-	sort.Strings(metricsInGroup)
-
-	for _, err := range parseErrors {
-		parseErrs = append(parseErrs, err.Error())
-	}
-
-	mir.RuleGroups = append(mir.RuleGroups, analyse.RuleGroupMetrics{
-		Namespace:   ns,
-		GroupName:   group.Name,
-		Metrics:     metricsInGroup,
-		ParseErrors: parseErrs,
-	})
 
 	return nil
 }

--- a/pkg/commands/analyse_rules_test.go
+++ b/pkg/commands/analyse_rules_test.go
@@ -52,7 +52,7 @@ func TestParseMetricsInRuleFile(t *testing.T) {
 
 	for _, ns := range nss {
 		for _, group := range ns.Groups {
-			err := parseMetricsInRuleGroup(output, group, ns.Namespace)
+			err := analyse.ParseMetricsInRuleGroup(output, group, ns.Namespace)
 			require.NoError(t, err)
 		}
 	}


### PR DESCRIPTION
This PR allows external consumers to use the metrics analysis that was previously entirely encapsulated in the analyse commands.