### PR TITLE
Allow usage of HTTP_PROXY and HTTPS_PROXY.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
+## unreleased
+
+* [ENHANCEMENT] Allow usage of HTTP_PROXY and HTTPS_PROXY. #216
+
 ## v0.10.4
 
 * [CHANGE] Update go image to v1.16.8. #213

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -72,7 +72,10 @@ func New(cfg Config) (*CortexClient, error) {
 	}
 
 	if tlsConfig != nil {
-		transport := &http.Transport{TLSClientConfig: tlsConfig}
+		transport := &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: tlsConfig,
+		}
 		client = http.Client{Transport: transport}
 	}
 


### PR DESCRIPTION
These variables are supported if the default `http.Client` and `http.Transport`
are used, but due to custom instances being used, the support is lost. This
commit manually adds it back.

To validate, I tried setting the variables to bogus values to see if the requests would fail:

Before fix, the proxy setting is ignored:
```
HTTPS_PROXY=http://localhost:9999/ ./cmd/cortextool/cortextool rules print --address=https://www.example.com/ --id=1
INFO[0000] no rule groups currently exist for this user 
```

After fix, it is not ignored:
```
HTTPS_PROXY=http://localhost:9999/ ./cmd/cortextool/cortextool rules print --address=https://www.example.com/ --id=1
ERRO[0000] error during request to cortex api            error="Get \"https://www.example.com/api/v1/rules\": proxyconnect tcp: dial tcp 127.0.0.1:9999: connect: connection refused" method=GET url="https://www.example.com/api/v1/rules"
FATA[0000] unable to read rules from cortex, Get "https://www.example.com/api/v1/rules": proxyconnect tcp: dial tcp 127.0.0.1:9999: connect: connection refused 
```