### PR TITLE
Fix homebrew stage for goreleaser.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -138,6 +138,8 @@ dockers:
     - "--label=homepage=https://grafana.com"
 brews:
   -
+    ids:
+    - needed-for-homebrew
     tap:
       owner: grafana
       name: homebrew-grafana


### PR DESCRIPTION
With the addition of benchtool, the release process is broken:

    homebrew tap formula
    release failed after 113.62s error=one tap can handle only archive of an
    OS/Arch combination. Consider using ids in the brew section

This is because the tap stage expects to only find archives for cortextool, but
now also finds them for benchtool. The fix is to limit the archives inspected
by the homebrew step to those actually required for the step.

