### PR TITLE
Benchtool: add `-bench.write.proxy-url` argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
+## unreleased
+
+* [ENHANCEMENT] Benchtool: add `-bench.write.proxy-url` argument for configuring the Prometheus remote-write client with a HTTP proxy URL. #223
+
 ## v0.10.6
 
 * [FEATURE] Rules check for Loki now supports `pattern`.


### PR DESCRIPTION
This allows configuring the Prometheus remote-write client with a HTTP proxy URL.

Getting the client to support the HTTP[S]_PROXY environment variables is not
straightforward, as the creation of the HTTP transport is deep in the upstream
code. Additionally, the client appears to have it's own mechanism for
configuring a HTTP proxy, so it would be safer to use that without meddling.

---

Tested by running benchtool with a proxy to a useless URL (localhost):

```
$ ./cmd/benchtool/benchtool \
    -bench.write.enabled=true \
    -bench.query.enabled=false \
    -bench.ring-check.enabled=false \
    -log.level=debug \
    -bench.write.endpoint=example.com \
    -bench.write.proxy-url=http://localhost/
level=info ts=2021-11-15T19:07:11.782043772Z msg="building workload"
level=info ts=2021-11-15T19:07:11.782313845Z msg="starting benchmarker"
level=debug ts=2021-11-15T19:07:11.785365452Z msg="sending timeseries batch" num_series=1000
level=warn ts=2021-11-15T19:07:11.786947337Z msg="unable to send batch" err="remote-write request failed: Post \"http://example.com/api/v1/push\": proxyconnect tcp: dial tcp 127.0.0.1:80: connect: connection refused"
```

For comparison, this is the output without giving the proxy:

```
$ ./cmd/benchtool/benchtool \
    -bench.write.enabled=true \
    -bench.query.enabled=false \
    -bench.ring-check.enabled=false \
    -log.level=debug \
    -bench.write.endpoint=example.com
level=info ts=2021-11-15T19:01:38.635670139Z msg="building workload"
level=info ts=2021-11-15T19:01:38.635920193Z msg="starting benchmarker"
run
level=debug ts=2021-11-15T19:01:38.639106715Z msg="sending timeseries batch" num_series=1000
test
level=warn ts=2021-11-15T19:01:39.155580753Z msg="unable to send batch" err="remote-write request failed: server returned HTTP status 404 Not Found: <?xml version=\"1.0\" encoding=\"iso-8859-1\"?>"
```
