### PR TITLE
Fix legend displaying wrong symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## unreleased/master
 
-[FEATURE] Support Arm64 on Darwin for all binaries (benchtool etc). #215
+* [FEATURE] Support Arm64 on Darwin for all binaries (benchtool etc). #215
+* [BUGFIX] Fix `cortextool rules` legends displaying wrong symbols for updates and deletions. #226
 
 ## v0.10.7
 

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -122,10 +122,10 @@ func (p *Printer) PrintComparisonResult(results []rules.NamespaceChange, verbose
 			p.Println("[green]  +[reset] created")
 		}
 		if updated > 0 {
-			p.Println("[yellow]  +[reset] updated")
+			p.Println("[yellow]  ~[reset] updated")
 		}
 		if deleted > 0 {
-			p.Println("[red]  +[reset] deleted")
+			p.Println("[red]  -[reset] deleted")
 		}
 		fmt.Println()
 		fmt.Println("The following changes will be made if the provided rule set is synced:")

--- a/pkg/rules/compare.go
+++ b/pkg/rules/compare.go
@@ -183,10 +183,10 @@ func PrintComparisonResult(results []NamespaceChange, verbose bool) error {
 			colorstring.Println("[green]  +[reset] created") //nolint
 		}
 		if updated > 0 {
-			colorstring.Println("[yellow]  +[reset] updated") //nolint
+			colorstring.Println("[yellow]  ~[reset] updated") //nolint
 		}
 		if deleted > 0 {
-			colorstring.Println("[red]  +[reset] deleted") //nolint
+			colorstring.Println("[red]  -[reset] deleted") //nolint
 		}
 		fmt.Println()
 		fmt.Println("The following changes will be made if the provided rule set is synced:")
@@ -222,7 +222,7 @@ func PrintComparisonResult(results []NamespaceChange, verbose bool) error {
 					oldYaml, _ := yaml.Marshal(c.Original)
 					separated = strings.Split(string(oldYaml), "\n")
 					for _, l := range separated {
-						colorstring.Printf("[red]+ %v\n", l)
+						colorstring.Printf("[red]- %v\n", l)
 					}
 				}
 			}


### PR DESCRIPTION
This commit fixes a display error for "updated" and "deleted" items
which would always display a "+" symbol no matter what.