### PR TITLE
Allow authentication with bearer token or JWT token

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -123,7 +123,7 @@ func (r *CortexClient) doRequest(path, method string, payload []byte) (*http.Res
 			"url":    req.URL.String(),
 			"method": req.Method,
 			"error":  err,
-		}).Errorln("atmost one of basic auth or auth token should be configured")
+		}).Errorln("error during request to cortex api")
 		return nil, err
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -117,6 +117,16 @@ func (r *CortexClient) doRequest(path, method string, payload []byte) (*http.Res
 		return nil, err
 	}
 
+	if r.user != "" && r.authToken != "" {
+		err := errors.New("atmost one of basic auth or auth token should be configured")
+		log.WithFields(log.Fields{
+			"url":    req.URL.String(),
+			"method": req.Method,
+			"error":  err,
+		}).Errorln("atmost one of basic auth or auth token should be configured")
+		return nil, err
+	}
+
 	if r.user != "" {
 		req.SetBasicAuth(r.user, r.key)
 	} else if r.key != "" {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -134,7 +134,7 @@ func (r *CortexClient) doRequest(path, method string, payload []byte) (*http.Res
 	}
 
 	if r.authToken != "" {
-		req.Header.Add("Authorization", r.authToken)
+		req.Header.Add("Authorization", "Bearer "+r.authToken)
 	}
 
 	req.Header.Add("X-Scope-OrgID", r.id)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,17 +33,19 @@ type Config struct {
 	Address         string `yaml:"address"`
 	ID              string `yaml:"id"`
 	TLS             tls.ClientConfig
-	UseLegacyRoutes bool `yaml:"use_legacy_routes"`
+	UseLegacyRoutes bool   `yaml:"use_legacy_routes"`
+	AuthToken       string `yaml:"auth_token"`
 }
 
 // CortexClient is used to get and load rules into a cortex ruler
 type CortexClient struct {
-	user     string
-	key      string
-	id       string
-	endpoint *url.URL
-	Client   http.Client
-	apiPath  string
+	user      string
+	key       string
+	id        string
+	endpoint  *url.URL
+	Client    http.Client
+	apiPath   string
+	authToken string
 }
 
 // New returns a new Client
@@ -85,12 +87,13 @@ func New(cfg Config) (*CortexClient, error) {
 	}
 
 	return &CortexClient{
-		user:     cfg.User,
-		key:      cfg.Key,
-		id:       cfg.ID,
-		endpoint: endpoint,
-		Client:   client,
-		apiPath:  path,
+		user:      cfg.User,
+		key:       cfg.Key,
+		id:        cfg.ID,
+		endpoint:  endpoint,
+		Client:    client,
+		apiPath:   path,
+		authToken: cfg.AuthToken,
 	}, nil
 }
 
@@ -118,6 +121,10 @@ func (r *CortexClient) doRequest(path, method string, payload []byte) (*http.Res
 		req.SetBasicAuth(r.user, r.key)
 	} else if r.key != "" {
 		req.SetBasicAuth(r.id, r.key)
+	}
+
+	if r.authToken != "" {
+		req.Header.Add("Authorization", r.authToken)
 	}
 
 	req.Header.Add("X-Scope-OrgID", r.id)

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -90,6 +90,7 @@ type RuleCommand struct {
 // Register rule related commands and flags with the kingpin application
 func (r *RuleCommand) Register(app *kingpin.Application) {
 	rulesCmd := app.Command("rules", "View & edit rules stored in cortex.").PreAction(r.setup)
+	rulesCmd.Flag("authToken", "Authentication token for bearer token or JWT auth, alternatively set CORTEX_AUTH_TOKEN.").Default("").Envar("CORTEX_AUTH_TOKEN").StringVar(&r.ClientConfig.AuthToken)
 	rulesCmd.Flag("user", "API user to use when contacting cortex, alternatively set CORTEX_API_USER. If empty, CORTEX_TENANT_ID will be used instead.").Default("").Envar("CORTEX_API_USER").StringVar(&r.ClientConfig.User)
 	rulesCmd.Flag("key", "API key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&r.ClientConfig.Key)
 	rulesCmd.Flag("backend", "Backend type to interact with: <cortex|loki>").Default("cortex").EnumVar(&r.Backend, backends...)


### PR DESCRIPTION
The client at this point only supports basic authentication. This PR allows a bearer or JWT token to be used for authentication. 