### PR TITLE
fix(remote-read): return err instead of nil

### DIFF
--- a/pkg/commands/remote_read.go
+++ b/pkg/commands/remote_read.go
@@ -304,7 +304,7 @@ func (c *RemoteReadCommand) stats(k *kingpin.ParseContext) error {
 
 	timeseries, err := query(context.Background())
 	if err != nil {
-		return nil
+		return err
 	}
 
 	num := struct {


### PR DESCRIPTION
![Screen Shot 2022-01-18 at 17 40 19](https://user-images.githubusercontent.com/16493751/149958397-2bd5b99d-a3ba-4928-8014-bd4cc7ff3069.png)

**Actual Behavior**
```
$ cortextool remote-read stats --address http://10.10.10.10:30090 --selector '{__name__=~"istio.*"}' --remote-read-path /api/v1/read --log.level debug --read-timeout 60s

INFO[0000] log level set to debug
INFO[0000] Created remote read client using endpoint 'http://10.10.10.10:30090/api/v1/read'
INFO[0000] Querying time from=2022-01-18T16:01:52+03:00 to=2022-01-18T17:01:52+03:00 with selector={__name__=~"istio.*"}

$ echo $?
0
```

**Expected Behavior**

```
INFO[0000] log level set to debug                       
INFO[0000] Created remote read client using endpoint 'http://10.10.10.10:30090/api/v1/read' 
INFO[0000] Querying time from=2022-01-18T16:39:20+03:00 to=2022-01-18T17:39:20+03:00 with selector={__name__=~"istio.*"} 
___2remote_read_stats: error: remote server http://10.10.10.10:30090/api/v1/read returned HTTP status 400 Bad Request: exceeded sample limit (50000000), try --help

Process finished with the exit code 1
```

@eminaktas @yasintahaerol

Signed-off-by: Furkan <furkan.turkal@trendyol.com>
Co-authored-by: Emin <emin.aktas@trendyol.com>
Co-authored-by: Yasin <yasintaha.erol@trendyol.com>