### PR TITLE
fix(analyse_prometheus): store errors instead of exit

### DIFF
--- a/pkg/analyse/prometheus.go
+++ b/pkg/analyse/prometheus.go
@@ -7,6 +7,8 @@ type MetricsInPrometheus struct {
 
 	InUseMetricCounts      []MetricCount `json:"in_use_metric_counts"`
 	AdditionalMetricCounts []MetricCount `json:"additional_metric_counts"`
+
+	Errors []string `json:"errors"`
 }
 
 type MetricCount struct {


### PR DESCRIPTION
Fixes #236

Make sure you have `metrics-in-grafana.json` file in the directory.

```golang
$ go run ./cmd/cortextool analyse prometheus --address <ADDR> --log.level="debug" --read-timeout=5m
```

![Screen Shot 2022-01-20 at 16 22 23](https://user-images.githubusercontent.com/16493751/150353572-4fc1adf0-a7a1-419d-adf8-ad453aff457e.png)

Signed-off-by: Furkan <furkan.turkal@trendyol.com>
Co-authored-by: Emin <emin.aktas@trendyol.com>
Co-authored-by: Yasin <yasintaha.erol@trendyol.com>
Co-authored-by: Batuhan <batuhan.apaydin@trendyol.com>