### PR TITLE
Update grafana-tools/sdk dependency to support datasources as a map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,3 +78,7 @@ replace github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-
 // Required for Alertmanager
 
 replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.8.1
+
+// Grafana SDK override. This can be removed when the SDK natively supports a dashboard -> panel -> datasource which is
+// a map, rather than a string. https://github.com/grafana-tools/sdk/pull/190
+replace github.com/grafana-tools/sdk => github.com/csmarchbanks/sdk v0.0.0-20220120205302-870d00a83f4e

--- a/go.sum
+++ b/go.sum
@@ -594,6 +594,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/csmarchbanks/sdk v0.0.0-20220120205302-870d00a83f4e h1:FjcnI9tmUibKj0UH9P761WwkEhAWUAinuuKVI2SyEB4=
+github.com/csmarchbanks/sdk v0.0.0-20220120205302-870d00a83f4e/go.mod h1:AHHlOEv1+GGQ3ktHMlhuTUwo3zljV3QJbC0+8o2kn+4=
 github.com/cucumber/godog v0.8.1/go.mod h1:vSh3r/lM+psC1BPXvdkSEuNjmXfpVqrMGYAElF6hxnA=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=

--- a/vendor/github.com/grafana-tools/sdk/board.go
+++ b/vendor/github.com/grafana-tools/sdk/board.go
@@ -83,7 +83,7 @@ type (
 		Type        string      `json:"type"`
 		Auto        bool        `json:"auto,omitempty"`
 		AutoCount   *int        `json:"auto_count,omitempty"`
-		Datasource  *string     `json:"datasource"`
+		Datasource  interface{} `json:"datasource"`
 		Refresh     BoolInt     `json:"refresh"`
 		Options     []Option    `json:"options"`
 		IncludeAll  bool        `json:"includeAll"`
@@ -111,23 +111,23 @@ type (
 		Value interface{}        `json:"value"` // TODO select more precise type
 	}
 	Annotation struct {
-		Name        string   `json:"name"`
-		Datasource  *string  `json:"datasource"`
-		ShowLine    bool     `json:"showLine"`
-		IconColor   string   `json:"iconColor"`
-		LineColor   string   `json:"lineColor"`
-		IconSize    uint     `json:"iconSize"`
-		Enable      bool     `json:"enable"`
-		Query       string   `json:"query"`
-		Expr        string   `json:"expr"`
-		Step        string   `json:"step"`
-		TextField   string   `json:"textField"`
-		TextFormat  string   `json:"textFormat"`
-		TitleFormat string   `json:"titleFormat"`
-		TagsField   string   `json:"tagsField"`
-		Tags        []string `json:"tags"`
-		TagKeys     string   `json:"tagKeys"`
-		Type        string   `json:"type"`
+		Name        string      `json:"name"`
+		Datasource  interface{} `json:"datasource"`
+		ShowLine    bool        `json:"showLine"`
+		IconColor   string      `json:"iconColor"`
+		LineColor   string      `json:"lineColor"`
+		IconSize    uint        `json:"iconSize"`
+		Enable      bool        `json:"enable"`
+		Query       string      `json:"query"`
+		Expr        string      `json:"expr"`
+		Step        string      `json:"step"`
+		TextField   string      `json:"textField"`
+		TextFormat  string      `json:"textFormat"`
+		TitleFormat string      `json:"titleFormat"`
+		TagsField   string      `json:"tagsField"`
+		Tags        []string    `json:"tags"`
+		TagKeys     string      `json:"tagKeys"`
+		Type        string      `json:"type"`
 	}
 	// Link represents link to another dashboard or external weblink
 	Link struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -455,7 +455,7 @@ github.com/googleapis/gax-go/v2/apierror/internal/proto
 github.com/gorilla/mux
 # github.com/gosimple/slug v1.1.1
 github.com/gosimple/slug
-# github.com/grafana-tools/sdk v0.0.0-20210808170449-9de4d14888c5
+# github.com/grafana-tools/sdk v0.0.0-20210808170449-9de4d14888c5 => github.com/csmarchbanks/sdk v0.0.0-20220120205302-870d00a83f4e
 ## explicit
 github.com/grafana-tools/sdk
 # github.com/grafana/dskit v0.0.0-20211103155626-4e784973d341
@@ -1184,3 +1184,4 @@ rsc.io/binaryregexp/syntax
 # github.com/gocql/gocql => github.com/grafana/gocql v0.0.0-20200605141915-ba5dc39ece85
 # github.com/bradfitz/gomemcache => github.com/themihai/gomemcache v0.0.0-20180902122335-24332e2d58ab
 # github.com/hashicorp/consul => github.com/hashicorp/consul v1.8.1
+# github.com/grafana-tools/sdk => github.com/csmarchbanks/sdk v0.0.0-20220120205302-870d00a83f4e


### PR DESCRIPTION
As of Grafana 8.3.0, the dashboard schema permits a datasource to be a map, defining the uid, and type of the datasource.

The upstream grafana-tools/sdk, (which is used in the `analyse dashboard` command) still expects the previous behavior, and will fail to unmarshal a dashboard which uses this new schema.

This PR replaces the dependency with a branch which fixes the problem, but is not yet accepted into the upstream grafana-tools/sdk main branch.

See grafana-tools/sdk#190 for details.

This PR *could* languish until that PR is merged, however this fix is needed for some downstream projects which depend upon cortextool, so I'm mocking up the interim workaround for anyone else who finds themselves in the same situation.