### PR TITLE
Allow authentication with bearer token on alerts and alertmanager commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Config commands interact with the Cortex api and read/create/update/delete user 
 | CORTEX_ADDRESS    | `address`  | Address of the API of the desired Cortex cluster.                                                              |
 | CORTEX_API_USER   | `user`     | In cases where the Cortex API is set behind a basic auth gateway, a user can be set as a basic auth user. If empty and CORTEX_API_KEY is set, CORTEX_TENANT_ID will be used instead. |
 | CORTEX_API_KEY    | `key`      | In cases where the Cortex API is set behind a basic auth gateway, a key can be set as a basic auth password. |
-| CORTEX_AUTH_TOKEN | `authToken`| In case where the Cortex API is set behind gateway authenticating by bearer token, a token can be set as a bearer token header. |
+| CORTEX_AUTH_TOKEN | `authToken`| In cases where the Cortex API is set behind gateway authenticating by bearer token, a token can be set as a bearer token header. |
 | CORTEX_TENANT_ID  | `id`       | The tenant ID of the Cortex instance to interact with.                                                        |
 
 #### Alertmanager

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Config commands interact with the Cortex api and read/create/update/delete user 
 
 #### Configuration
 
-| Env Variables     | Flag      | Description                                                                                                   |
-| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
-| CORTEX_ADDRESS    | `address` | Address of the API of the desired Cortex cluster.                                                              |
-| CORTEX_API_USER   | `user`    | In cases where the Cortex API is set behind a basic auth gateway, a user can be set as a basic auth user. If empty and CORTEX_API_KEY is set, CORTEX_TENANT_ID will be used instead. |
-| CORTEX_API_KEY    | `key`     | In cases where the Cortex API is set behind a basic auth gateway, a key can be set as a basic auth password. |
-| CORTEX_TENANT_ID | `id`      | The tenant ID of the Cortex instance to interact with.                                                        |
+| Env Variables     | Flag       | Description                                                                                                   |
+| ----------------- | ---------  | ------------------------------------------------------------------------------------------------------------- |
+| CORTEX_ADDRESS    | `address`  | Address of the API of the desired Cortex cluster.                                                              |
+| CORTEX_API_USER   | `user`     | In cases where the Cortex API is set behind a basic auth gateway, a user can be set as a basic auth user. If empty and CORTEX_API_KEY is set, CORTEX_TENANT_ID will be used instead. |
+| CORTEX_API_KEY    | `key`      | In cases where the Cortex API is set behind a basic auth gateway, a key can be set as a basic auth password. |
+| CORTEX_AUTH_TOKEN | `authToken`| In case where the Cortex API is set behind gateway authenticating by bearer token, a token can be set as a bearer token header. |
+| CORTEX_TENANT_ID  | `id`       | The tenant ID of the Cortex instance to interact with.                                                        |
 
 #### Alertmanager
 

--- a/pkg/commands/alerts.go
+++ b/pkg/commands/alerts.go
@@ -65,6 +65,7 @@ func (a *AlertmanagerCommand) Register(app *kingpin.Application) {
 	alertCmd := app.Command("alertmanager", "View & edit alertmanager configs stored in cortex.").PreAction(a.setup)
 	alertCmd.Flag("address", "Address of the cortex cluster, alternatively set CORTEX_ADDRESS.").Envar("CORTEX_ADDRESS").Required().StringVar(&a.ClientConfig.Address)
 	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
+	alertCmd.Flag("authToken", "Authentication token for bearer token or JWT auth, alternatively set CORTEX_AUTH_TOKEN.").Default("").Envar("CORTEX_AUTH_TOKEN").StringVar(&a.ClientConfig.AuthToken)
 	alertCmd.Flag("user", "API user to use when contacting cortex, alternatively set CORTEX_API_USER. If empty, CORTEX_TENANT_ID will be used instead.").Default("").Envar("CORTEX_API_USER").StringVar(&a.ClientConfig.User)
 	alertCmd.Flag("key", "API key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&a.ClientConfig.Key)
 	alertCmd.Flag("tls-ca-path", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_PATH.").Default("").Envar("CORTEX_TLS_CA_PATH").StringVar(&a.ClientConfig.TLS.CAPath)
@@ -143,6 +144,7 @@ func (a *AlertCommand) Register(app *kingpin.Application) {
 	alertCmd := app.Command("alerts", "View active alerts in alertmanager.").PreAction(a.setup)
 	alertCmd.Flag("address", "Address of the cortex cluster, alternatively set CORTEX_ADDRESS.").Envar("CORTEX_ADDRESS").Required().StringVar(&a.ClientConfig.Address)
 	alertCmd.Flag("id", "Cortex tenant id, alternatively set CORTEX_TENANT_ID.").Envar("CORTEX_TENANT_ID").Required().StringVar(&a.ClientConfig.ID)
+	alertCmd.Flag("authToken", "Authentication token for bearer token or JWT auth, alternatively set CORTEX_AUTH_TOKEN.").Default("").Envar("CORTEX_AUTH_TOKEN").StringVar(&a.ClientConfig.AuthToken)
 	alertCmd.Flag("user", "API user to use when contacting cortex, alternatively set CORTEX_API_USER. If empty, CORTEX_TENANT_ID will be used instead.").Default("").Envar("CORTEX_API_USER").StringVar(&a.ClientConfig.User)
 	alertCmd.Flag("key", "API key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&a.ClientConfig.Key)
 


### PR DESCRIPTION
Cortextool client only supports authToken on rules command. This PR adds authToken argument to alerts and alertmanager commands.