### PR TITLE
Analyse grafana: Use minimal schema

### DIFF
--- a/pkg/analyse/dashboard.go
+++ b/pkg/analyse/dashboard.go
@@ -1,0 +1,36 @@
+package analyse
+
+type (
+	Board struct {
+		ID         uint       `json:"id,omitempty"`
+		UID        string     `json:"uid,omitempty"`
+		Slug       string     `json:"slug"`
+		Title      string     `json:"title"`
+		Panels     []*Panel   `json:"panels"`
+		Rows       []*Row     `json:"rows"`
+		Templating Templating `json:"templating"`
+	}
+	Templating struct {
+		List []TemplateVar `json:"list"`
+	}
+	TemplateVar struct {
+		Name  string      `json:"name"`
+		Query interface{} `json:"query"`
+		Type  string      `json:"type"`
+	}
+	Panel struct {
+		Targets []Target `json:"targets,omitempty"`
+		Title   string   `json:"title"`  // general
+		Panels  []Panel  `json:"panels"` //row panel
+		Type    string   `json:"type"`
+	}
+	Target struct {
+		RefID      string `json:"refId"`
+		Datasource string `json:"datasource,omitempty"`
+		// For Prometheus
+		Expr string `json:"expr,omitempty"`
+	}
+	Row struct {
+		Panels []Panel `json:"panels"`
+	}
+)

--- a/pkg/analyse/dashboard.go
+++ b/pkg/analyse/dashboard.go
@@ -20,8 +20,8 @@ type (
 	}
 	Panel struct {
 		Targets []Target `json:"targets,omitempty"`
-		Title   string   `json:"title"`  // general
-		Panels  []Panel  `json:"panels"` //row panel
+		Title   string   `json:"title"`
+		Panels  []Panel  `json:"panels"` // row panel type
 		Type    string   `json:"type"`
 	}
 	Target struct {

--- a/pkg/analyse/grafana.go
+++ b/pkg/analyse/grafana.go
@@ -33,6 +33,7 @@ func ParseMetricsInBoard(mig *MetricsInGrafana, board Board) {
 	// Iterate through all the panels and collect metrics
 	for _, panel := range board.Panels {
 		parseErrors = append(parseErrors, metricsFromPanel(*panel, metrics)...)
+		// row panel
 		if panel.Panels != nil {
 			for _, subPanel := range panel.Panels {
 				parseErrors = append(parseErrors, metricsFromPanel(subPanel, metrics)...)
@@ -99,8 +100,8 @@ func metricsFromTemplating(templating Templating, metrics map[string]struct{}) [
 			}
 			err := parseQuery(query, metrics)
 			if err != nil {
-				parseErrors = append(parseErrors, errors.Wrapf(err, "query=%v", query))
-				log.Debugln("msg", "promql parse error", "err", err, "query", query)
+				parseErrors = append(parseErrors, errors.Wrapf(err, "error parsing templating query: %v", query))
+				log.Debugln("msg", "promql parse error: templating query", "err", err, "query", query)
 				continue
 			}
 		} else {
@@ -113,11 +114,12 @@ func metricsFromTemplating(templating Templating, metrics map[string]struct{}) [
 	return parseErrors
 }
 
+// for now, only look at panels with a prometheus datasource/targets
 func metricsFromPanel(panel Panel, metrics map[string]struct{}) []error {
 	var parseErrors []error
 
 	if panel.Targets == nil {
-		parseErrors = append(parseErrors, fmt.Errorf("unsupported panel type: %q", panel.Type))
+		parseErrors = append(parseErrors, fmt.Errorf("unsupported panel type (no targets in panel): %q", panel.Type))
 		return parseErrors
 	}
 

--- a/pkg/commands/analyse_dashboards.go
+++ b/pkg/commands/analyse_dashboards.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/grafana-tools/sdk"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/grafana/cortex-tools/pkg/analyse"
@@ -21,7 +20,7 @@ func (cmd *DashboardAnalyseCommand) run(k *kingpin.ParseContext) error {
 	output.OverallMetrics = make(map[string]struct{})
 
 	for _, file := range cmd.DashFilesList {
-		var board sdk.Board
+		var board analyse.Board
 		buf, err := loadFile(file)
 		if err != nil {
 			return err

--- a/pkg/commands/analyse_grafana.go
+++ b/pkg/commands/analyse_grafana.go
@@ -41,12 +41,14 @@ func (cmd *GrafanaAnalyseCommand) run(k *kingpin.ParseContext) error {
 	}
 
 	for _, link := range boardLinks {
-		board, _, err := c.GetDashboardByUID(ctx, link.UID)
+		//board, _, err := c.GetDashboardByUID(ctx, link.UID)
+		_, _, err := c.GetDashboardByUID(ctx, link.UID)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s for %s %s\n", err, link.UID, link.Title)
 			continue
 		}
-		analyse.ParseMetricsInBoard(output, board)
+		// TODO: convert into new board type
+		//analyse.ParseMetricsInBoard(output, board)
 	}
 
 	err = writeOut(output, cmd.outputFile)

--- a/pkg/commands/analyse_grafana_test.go
+++ b/pkg/commands/analyse_grafana_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/grafana-tools/sdk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -25,7 +24,7 @@ var dashboardMetrics = []string{
 }
 
 func TestParseMetricsInBoard(t *testing.T) {
-	var board sdk.Board
+	var board analyse.Board
 	output := &analyse.MetricsInGrafana{}
 	output.OverallMetrics = make(map[string]struct{})
 
@@ -40,7 +39,7 @@ func TestParseMetricsInBoard(t *testing.T) {
 }
 
 func TestParseMetricsInBoardWithTimeseriesPanel(t *testing.T) {
-	var board sdk.Board
+	var board analyse.Board
 	output := &analyse.MetricsInGrafana{}
 	output.OverallMetrics = make(map[string]struct{})
 


### PR DESCRIPTION
The upstream [sdk](https://github.com/grafana-tools/sdk) library is now quite out of sync with Grafana and is infrequently updated (as is this tool), and this often results in deserialization errors and breakage (e.g. https://github.com/grafana/support-escalations/issues/2089)

This PR adds a minimal schema which preserves existing functionality of the tool while avoiding all of the data structures and fields not necessary to its functionality. I think it will make this easier to maintain and avoids forking the `sdk` library.

Deserialization additionally tested on [kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin). There are also two dashboards included in unit tests.

Closes https://github.com/grafana/cortex-tools/issues/241
Deprecates https://github.com/grafana/cortex-tools/pull/239

cc @eamonryan @rgeyer 