### PR TITLE
List used labels by metric in grafana

### DIFF
--- a/pkg/analyse/grafana.go
+++ b/pkg/analyse/grafana.go
@@ -20,16 +20,16 @@ type MetricsInGrafana struct {
 }
 
 type DashboardMetrics struct {
-	Slug        string   `json:"slug"`
-	UID         string   `json:"uid,omitempty"`
-	Title       string   `json:"title"`
-	Metrics     []string `json:"metrics"`
+	Slug           string             `json:"slug"`
+	UID            string             `json:"uid,omitempty"`
+	Title          string             `json:"title"`
+	Metrics        []string           `json:"metrics"`
 	LabelsByMetric map[string][]Label `json:"labels_by_metric"`
-	ParseErrors []string `json:"parse_errors"`
+	ParseErrors    []string           `json:"parse_errors"`
 }
 
 type Label struct {
-	Name string `json:"name"`
+	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
@@ -74,11 +74,11 @@ func ParseMetricsInBoard(mig *MetricsInGrafana, board sdk.Board) {
 	sort.Strings(metricsInBoard)
 
 	mig.Dashboards = append(mig.Dashboards, DashboardMetrics{
-		Slug:        board.Slug,
-		UID:         board.UID,
-		Title:       board.Title,
-		Metrics:     metricsInBoard,
-		ParseErrors: parseErrs,
+		Slug:           board.Slug,
+		UID:            board.UID,
+		Title:          board.Title,
+		Metrics:        metricsInBoard,
+		ParseErrors:    parseErrs,
 		LabelsByMetric: metrics,
 	})
 
@@ -167,7 +167,7 @@ func parseQuery(query string, metrics map[string][]Label) error {
 				labels = append(
 					labels,
 					Label{Name: l.Name, Value: l.Value},
-					)
+				)
 			}
 			metrics[n.Name] = labels
 

--- a/pkg/analyse/grafana.go
+++ b/pkg/analyse/grafana.go
@@ -24,12 +24,18 @@ type DashboardMetrics struct {
 	UID         string   `json:"uid,omitempty"`
 	Title       string   `json:"title"`
 	Metrics     []string `json:"metrics"`
+	LabelsByMetric map[string][]Label `json:"labels_by_metric"`
 	ParseErrors []string `json:"parse_errors"`
+}
+
+type Label struct {
+	Name string `json:"name"`
+	Value string `json:"value"`
 }
 
 func ParseMetricsInBoard(mig *MetricsInGrafana, board sdk.Board) {
 	var parseErrors []error
-	metrics := make(map[string]struct{})
+	metrics := make(map[string][]Label)
 
 	// Iterate through all the panels and collect metrics
 	for _, panel := range board.Panels {
@@ -73,11 +79,12 @@ func ParseMetricsInBoard(mig *MetricsInGrafana, board sdk.Board) {
 		Title:       board.Title,
 		Metrics:     metricsInBoard,
 		ParseErrors: parseErrs,
+		LabelsByMetric: metrics,
 	})
 
 }
 
-func metricsFromTemplating(templating sdk.Templating, metrics map[string]struct{}) []error {
+func metricsFromTemplating(templating sdk.Templating, metrics map[string][]Label) []error {
 	parseErrors := []error{}
 	for _, templateVar := range templating.List {
 		if templateVar.Type != "query" {
@@ -114,7 +121,7 @@ func metricsFromTemplating(templating sdk.Templating, metrics map[string]struct{
 	return parseErrors
 }
 
-func metricsFromPanel(panel sdk.Panel, metrics map[string]struct{}) []error {
+func metricsFromPanel(panel sdk.Panel, metrics map[string][]Label) []error {
 	var parseErrors []error
 
 	targets := panel.GetTargets()
@@ -140,7 +147,7 @@ func metricsFromPanel(panel sdk.Panel, metrics map[string]struct{}) []error {
 	return parseErrors
 }
 
-func parseQuery(query string, metrics map[string]struct{}) error {
+func parseQuery(query string, metrics map[string][]Label) error {
 	query = strings.ReplaceAll(query, `$__interval`, "5m")
 	query = strings.ReplaceAll(query, `$interval`, "5m")
 	query = strings.ReplaceAll(query, `$resolution`, "5s")
@@ -155,7 +162,15 @@ func parseQuery(query string, metrics map[string]struct{}) error {
 
 	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
 		if n, ok := node.(*parser.VectorSelector); ok {
-			metrics[n.Name] = struct{}{}
+			var labels []Label
+			for _, l := range n.LabelMatchers {
+				labels = append(
+					labels,
+					Label{Name: l.Name, Value: l.Value},
+					)
+			}
+			metrics[n.Name] = labels
+
 		}
 
 		return nil


### PR DESCRIPTION
This PR adds  the labels used my each metric when running the `cortex-tools analyse grafana` command.

It adds a new field to the output called `labels_by_metric` that has the following format:

```json
      "labels_by_metric": {
        "<metric_name>": [
          "label_1",
          "label_2",
            ...
        ]
      }   
```