### PR TITLE
blockscopy: log min and max time when skipping a block because of min duration filter

### DIFF
--- a/cmd/blockscopy/main.go
+++ b/cmd/blockscopy/main.go
@@ -226,7 +226,10 @@ func copyBlocks(ctx context.Context, cfg config, logger log.Logger, m *metrics) 
 
 				blockDuration := time.Millisecond * time.Duration(meta.MaxTime-meta.MinTime)
 				if blockDuration < cfg.minBlockDuration {
-					level.Debug(logger).Log("msg", "skipping block, block duration is smaller than minimum duration", "blockDuration", blockDuration, "minimumDuration", cfg.minBlockDuration)
+					minTime := time.Unix(0, meta.MinTime*int64(time.Millisecond)).UTC()
+					maxTime := time.Unix(0, meta.MaxTime*int64(time.Millisecond)).UTC()
+
+					level.Debug(logger).Log("msg", "skipping block, block duration is smaller than minimum duration", "blockDuration", blockDuration, "minimumDuration", cfg.minBlockDuration, "min_time", minTime, "max_time", maxTime)
 					return nil
 				}
 			}


### PR DESCRIPTION
I plan to use the blockscopy tool shortly, and I would like to log the min and max time when skipping a block because of the min duration filter.