### PR TITLE
Reorder return values for SummarizeChanges in sync

### DIFF
--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -613,7 +613,7 @@ func (r *RuleCommand) executeChanges(ctx context.Context, changes []rules.Namesp
 		}
 	}
 
-	updated, created, deleted := rules.SummarizeChanges(changes)
+	created, updated, deleted := rules.SummarizeChanges(changes)
 	fmt.Println()
 	fmt.Printf("Sync Summary: %v Groups Created, %v Groups Updated, %v Groups Deleted\n", created, updated, deleted)
 	return nil


### PR DESCRIPTION
Swap "created" and "updated" to set values correctly.

Fixes #267.