### PR TITLE
Update build image to Go 1.22

### DIFF
--- a/cmd/benchtool/Dockerfile
+++ b/cmd/benchtool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.8-stretch as build
+FROM golang:1.22 as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir

--- a/cmd/cortextool/Dockerfile
+++ b/cmd/cortextool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.8-stretch as build
+FROM golang:1.22 as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir

--- a/cmd/e2ealerting/Dockerfile
+++ b/cmd/e2ealerting/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.8-stretch as build
+FROM golang:1.22 as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir

--- a/cmd/logtool/Dockerfile
+++ b/cmd/logtool/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.8-stretch as build
+FROM golang:1.22 as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir


### PR DESCRIPTION
This commit updates the build image to Go 1.22 as the docker build was failing on Go 1.16.