### PR TITLE
Add missing tzinfo package

### DIFF
--- a/cmd/cortextool/Dockerfile
+++ b/cmd/cortextool/Dockerfile
@@ -6,7 +6,7 @@ ENV GOPROXY=https://proxy.golang.org
 RUN make clean && make cortextool
 
 FROM       alpine:3.14
-RUN        apk add --update --no-cache ca-certificates
+RUN        apk add --update --no-cache ca-certificates tzdata
 COPY       --from=build /build_dir/cmd/cortextool/cortextool /usr/bin/cortextool
 EXPOSE     80
 ENTRYPOINT [ "/usr/bin/cortextool" ]


### PR DESCRIPTION
This commit adds the missing tzinfo package. This is required for timezones to work, for example, when validating Alertmanager configurations that contain time intervals.