### PR TITLE
Add support for extra-headers to cortextool rules commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## unreleased/master
 
+* [FEATURE] Add `--extra-headers` support for `cortextool rules` commands. #288
+
 ## v0.11.0
 
 * [FEATURE] Support Arm64 on Darwin for all binaries (benchtool etc). #215

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -33,19 +33,21 @@ type Config struct {
 	Address         string `yaml:"address"`
 	ID              string `yaml:"id"`
 	TLS             tls.ClientConfig
-	UseLegacyRoutes bool   `yaml:"use_legacy_routes"`
-	AuthToken       string `yaml:"auth_token"`
+	UseLegacyRoutes bool              `yaml:"use_legacy_routes"`
+	AuthToken       string            `yaml:"auth_token"`
+	ExtraHeaders    map[string]string `yaml:"extra_headers"`
 }
 
 // CortexClient is used to get and load rules into a cortex ruler
 type CortexClient struct {
-	user      string
-	key       string
-	id        string
-	endpoint  *url.URL
-	Client    http.Client
-	apiPath   string
-	authToken string
+	user         string
+	key          string
+	id           string
+	endpoint     *url.URL
+	Client       http.Client
+	apiPath      string
+	authToken    string
+	extraHeaders map[string]string
 }
 
 // New returns a new Client
@@ -87,13 +89,14 @@ func New(cfg Config) (*CortexClient, error) {
 	}
 
 	return &CortexClient{
-		user:      cfg.User,
-		key:       cfg.Key,
-		id:        cfg.ID,
-		endpoint:  endpoint,
-		Client:    client,
-		apiPath:   path,
-		authToken: cfg.AuthToken,
+		user:         cfg.User,
+		key:          cfg.Key,
+		id:           cfg.ID,
+		endpoint:     endpoint,
+		Client:       client,
+		apiPath:      path,
+		authToken:    cfg.AuthToken,
+		extraHeaders: cfg.ExtraHeaders,
 	}, nil
 }
 
@@ -135,6 +138,10 @@ func (r *CortexClient) doRequest(ctx context.Context, path, method string, paylo
 
 	if r.authToken != "" {
 		req.Header.Add("Authorization", "Bearer "+r.authToken)
+	}
+
+	for k, v := range r.extraHeaders {
+		req.Header.Add(k, v)
 	}
 
 	req.Header.Add("X-Scope-OrgID", r.id)

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -93,6 +93,8 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 	rulesCmd.Flag("user", "API user to use when contacting cortex, alternatively set CORTEX_API_USER. If empty, CORTEX_TENANT_ID will be used instead.").Default("").Envar("CORTEX_API_USER").StringVar(&r.ClientConfig.User)
 	rulesCmd.Flag("key", "API key to use when contacting cortex, alternatively set CORTEX_API_KEY.").Default("").Envar("CORTEX_API_KEY").StringVar(&r.ClientConfig.Key)
 	rulesCmd.Flag("backend", "Backend type to interact with: <cortex|loki>").Default("cortex").EnumVar(&r.Backend, backends...)
+	r.ClientConfig.ExtraHeaders = map[string]string{}
+	rulesCmd.Flag("extra-headers", "Extra headers to add to the requests in header=value format, alternatively set newline separated CORTEX_EXTRA_HEADERS.").Envar("CORTEX_EXTRA_HEADERS").StringMapVar(&r.ClientConfig.ExtraHeaders)
 
 	// Register rule commands
 	listCmd := rulesCmd.


### PR DESCRIPTION
Adding support for `--extra-headers` to the `cortextool rules` commands, similar to [the existing parameter in mimirtool](https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#rules).

This is needed for the new APIs in Grafana ([example PR](https://github.com/grafana/grafana/pull/100558)), which will allow loading rules with mimirtool and cortextool and converting them to Grafana rules. These APIs need some additional headers that can be currently set with mimirtool but not with cortextool.

Part of https://github.com/grafana/alerting-squad/issues/1031