### PR TITLE
fix[cortextool]: fix cortextool out of bounds when running export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 ## unreleased/master
 
 * [FEATURE] Add `--extra-headers` support for `cortextool rules` commands. #288
+* [BUGFIX] Fix out of bounds error on export with large timespans and/or series count.
 
 ## v0.11.0
 

--- a/pkg/backfill/backfill.go
+++ b/pkg/backfill/backfill.go
@@ -85,7 +85,7 @@ func CreateBlocks(input IteratorCreator, mint, maxt int64, maxSamplesInAppender 
 
 	var wroteHeader bool
 
-	for t := mint; t <= maxt; t = t + blockDuration {
+	for t := mint; t <= maxt; t = t + blockDuration/2 {
 		err := func() error {
 			w, err := tsdb.NewBlockWriter(log.NewNopLogger(), outputDir, blockDuration)
 			if err != nil {
@@ -101,7 +101,7 @@ func CreateBlocks(input IteratorCreator, mint, maxt int64, maxSamplesInAppender 
 			ctx := context.Background()
 			app := w.Appender(ctx)
 			i := input()
-			tsUpper := t + blockDuration
+			tsUpper := t + blockDuration/2
 			samplesCount := 0
 			for {
 				err := i.Next()

--- a/pkg/commands/remote_read.go
+++ b/pkg/commands/remote_read.go
@@ -404,7 +404,7 @@ func (c *RemoteReadCommand) export(k *kingpin.ParseContext) error {
 		return err
 	}
 
-	iterator := func() backfill.Iterator {
+	iteratorCreator := func() backfill.Iterator {
 		return newTimeSeriesIterator(timeseries)
 	}
 
@@ -421,7 +421,7 @@ func (c *RemoteReadCommand) export(k *kingpin.ParseContext) error {
 	defer pipeR.Close()
 
 	log.Infof("Store TSDB blocks in '%s'", c.tsdbPath)
-	if err := backfill.CreateBlocks(iterator, int64(mint), int64(maxt), 1000, c.tsdbPath, true, pipeW); err != nil {
+	if err := backfill.CreateBlocks(iteratorCreator, int64(mint), int64(maxt), 1000, c.tsdbPath, true, pipeW); err != nil {
 		return err
 	}
 

--- a/pkg/commands/remote_read_test.go
+++ b/pkg/commands/remote_read_test.go
@@ -1,11 +1,15 @@
 package commands
 
 import (
+	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/cortex-tools/pkg/backfill"
 )
 
 func TestTimeSeriesIterator(t *testing.T) {
@@ -143,4 +147,42 @@ func TestTimeSeriesIterator(t *testing.T) {
 		})
 	}
 
+}
+
+// TestEarlyCommit writes samples of many series that don't fit into the same
+// append commit. It makes sure that batching the samples into many commits
+// doesn't cause the appends to advance the head block too far and make future
+// appends invalid.
+func TestEarlyCommit(t *testing.T) {
+	maxSamplesPerBlock := 1000
+	series := 100
+	samples := 140
+
+	start := int64(time.Date(2023, 8, 30, 11, 42, 17, 0, time.UTC).UnixNano())
+	inc := int64(time.Minute / time.Millisecond)
+	end := start + (inc * int64(samples))
+	ts := make([]*prompb.TimeSeries, series)
+	for i := 0; i < series; i++ {
+		s := &prompb.TimeSeries{
+			Labels: []prompb.Label{
+				{
+					Name:  "__name__",
+					Value: fmt.Sprintf("metric_%d", i),
+				},
+			},
+			Samples: make([]prompb.Sample, samples),
+		}
+		for j := 0; j < samples; j++ {
+			s.Samples[j] = prompb.Sample{
+				Value:     float64(j),
+				Timestamp: start + (inc * int64(j)),
+			}
+		}
+		ts[i] = s
+	}
+	iterator := func() backfill.Iterator {
+		return newTimeSeriesIterator(ts)
+	}
+	err := backfill.CreateBlocks(iterator, start, end, maxSamplesPerBlock, t.TempDir(), true, io.Discard)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Hello everyone,

Just for background, cortextool has a similar issue to the one reported in mimirtool here: https://github.com/grafana/mimir/issues/6466. it occurs when performing exports.

```
# ./cortextool remote-read export --address "http://<omit>" --tsdb-path "./fuse-backup/cortex-20250408" --from="2025-04-08T06:00:00+07:00" --id="<omit>" --to="2025-04-08T19:00:00+07:00"
INFO[0000] Created remote read client using endpoint 'http://<ommit>/prometheus/api/v1/read'
INFO[0000] Using existing TSDB in path './fuse-backup/cortex-20250408'
INFO[0000] Querying time from=2025-04-08T06:00:00+07:00 to=2025-04-08T19:00:00+07:00 with selector=up
INFO[0004] Store TSDB blocks in './fuse-backup/cortex-20250408'
INFO[0019] BLOCK ULID                  MIN TIME                       MAX TIME                       DURATION     NUM SAMPLES  NUM CHUNKS   NUM SERIES   SIZE
INFO[0019] 01JRY5XGG1RTAMV2HHY29E0FH9  2025-04-07 23:00:00 +0000 UTC  2025-04-08 00:00:00 +0000 UTC  1h0m0s       789564       6643         3984         1MiB833KiB739B
cortextool: error: process blocks: add sample for metric={__name__="up",<omit>} ts=2025-04-08T07:20:21.247+07:00 value=1.000000: out of bounds, try --help
```

This issue has already been resolved in Mimir in the following pull request: https://github.com/grafana/mimir/pull/5700. In this PR, I’m simply replicating the changes from that one. Since the idea isn't originally mine, if submitting this PR is considered inappropriate, I’m happy to close it.

Thank you